### PR TITLE
Support Big Picture APIs.

### DIFF
--- a/src/greenworks_api.cc
+++ b/src/greenworks_api.cc
@@ -35,6 +35,7 @@ class SteamEvent : public greenworks::SteamClient::Observer {
   virtual void OnSteamServersDisconnected();
   virtual void OnSteamServerConnectFailure(int status_code);
   virtual void OnSteamShutdown();
+  virtual void OnGamepadTextInputDismissed(bool submitted, uint32 text);
 };
 
 void SteamEvent::OnGameOverlayActivated(bool is_active) {
@@ -76,6 +77,16 @@ void SteamEvent::OnSteamShutdown() {
   v8::Local<v8::Value> argv[] = { Nan::New("steam-shutdown").ToLocalChecked() };
   Nan::MakeCallback(
       Nan::New(g_persistent_steam_events), "on", 1, argv);
+}
+
+void SteamEvent::OnGamepadTextInputDismissed(bool submitted, uint32 text) {
+  Nan::HandleScope scope;
+  v8::Local<v8::Value> argv[] = {
+      Nan::New("gamepad-text-input-dismissed").ToLocalChecked(),
+      Nan::New(submitted),
+      Nan::New(text) };
+  Nan::MakeCallback(
+      Nan::New(g_persistent_steam_events), "on", 3, argv);
 }
 
 v8::Local<v8::Object> GetSteamUserCountType(int type_id) {

--- a/src/greenworks_api.cc
+++ b/src/greenworks_api.cc
@@ -724,10 +724,11 @@ NAN_METHOD(ShowGamepadTextInput) {
       info[0]->Int32Value());
   EGamepadTextInputLineMode input_line_mode =
       static_cast<EGamepadTextInputLineMode>(info[1]->Int32Value());
-  char* description = *(static_cast<v8::String::Utf8Value>(info[2]->ToString()));
+  char* description =
+      *(static_cast<v8::String::Utf8Value>(info[2]->ToString()));
   int char_max = info[3]->Int32Value();
   char* existing_text =
-     *(static_cast<v8::String::Utf8Value>(info[4]->ToString()));
+      *(static_cast<v8::String::Utf8Value>(info[4]->ToString()));
   bool success = SteamUtils()->ShowGamepadTextInput(
       input_mode, input_line_mode, description, char_max, existing_text);
   info.GetReturnValue().Set(Nan::New(success));

--- a/src/greenworks_utils.cc
+++ b/src/greenworks_utils.cc
@@ -118,6 +118,30 @@ void InitUserUgcList(v8::Handle<v8::Object> exports) {
   Nan::Set(exports, Nan::New("UserUGCList").ToLocalChecked(), ugc_list);
 }
 
+void InitGamepadTextInputMode(v8::Handle<v8::Object> exports) {
+  v8::Local<v8::Object> mode = Nan::New<v8::Object>();
+  mode->Set(Nan::New("Normal").ToLocalChecked(),
+            Nan::New(k_EGamepadTextInputModeNormal));
+  mode->Set(Nan::New("Password").ToLocalChecked(),
+            Nan::New(k_EGamepadTextInputModePassword));
+  Nan::Persistent<v8::Object> constructor;
+  constructor.Reset(mode);
+  Nan::Set(exports, Nan::New("GamepadTextInputMode").ToLocalChecked(), mode);
+}
+
+void InitGamepadTextInputLineMode(v8::Handle<v8::Object> exports) {
+  v8::Local<v8::Object> line_mode = Nan::New<v8::Object>();
+  line_mode->Set(Nan::New("SingleLine").ToLocalChecked(),
+            Nan::New(k_EGamepadTextInputLineModeSingleLine));
+  line_mode->Set(Nan::New("MultipleLines").ToLocalChecked(),
+            Nan::New(k_EGamepadTextInputLineModeMultipleLines));
+  Nan::Persistent<v8::Object> constructor;
+  constructor.Reset(line_mode);
+  Nan::Set(exports,
+           Nan::New("GamepadTextInputLIneMode").ToLocalChecked(),
+           line_mode);
+}
+
 void InitUserUgcListSortOrder(v8::Handle<v8::Object> exports) {
   v8::Local<v8::Object> ugc_list_sort_order = Nan::New<v8::Object>();
   ugc_list_sort_order->Set(Nan::New("CreationOrderDesc").ToLocalChecked(),

--- a/src/greenworks_utils.cc
+++ b/src/greenworks_utils.cc
@@ -132,13 +132,13 @@ void InitGamepadTextInputMode(v8::Handle<v8::Object> exports) {
 void InitGamepadTextInputLineMode(v8::Handle<v8::Object> exports) {
   v8::Local<v8::Object> line_mode = Nan::New<v8::Object>();
   line_mode->Set(Nan::New("SingleLine").ToLocalChecked(),
-            Nan::New(k_EGamepadTextInputLineModeSingleLine));
+                 Nan::New(k_EGamepadTextInputLineModeSingleLine));
   line_mode->Set(Nan::New("MultipleLines").ToLocalChecked(),
-            Nan::New(k_EGamepadTextInputLineModeMultipleLines));
+                 Nan::New(k_EGamepadTextInputLineModeMultipleLines));
   Nan::Persistent<v8::Object> constructor;
   constructor.Reset(line_mode);
   Nan::Set(exports,
-           Nan::New("GamepadTextInputLIneMode").ToLocalChecked(),
+           Nan::New("GamepadTextInputLineMode").ToLocalChecked(),
            line_mode);
 }
 

--- a/src/greenworks_utils.h
+++ b/src/greenworks_utils.h
@@ -21,6 +21,10 @@ void InitUserUgcListSortOrder(v8::Handle<v8::Object> exports);
 
 void InitUserUgcList(v8::Handle<v8::Object> exports);
 
+void InitGamepadTextInputMode(v8::Handle<v8::Object> exports);
+
+void InitGamepadTextInputLineMode(v8::Handle<v8::Object> exports);
+
 void sleep(int milliseconds);
 
 bool ReadFile(const char* path, char* &content, int& length);

--- a/src/steam_client.cc
+++ b/src/steam_client.cc
@@ -36,6 +36,8 @@ SteamClient::SteamClient() :
     steam_servers_disconnected_(this, &SteamClient::OnSteamServersDisconnected),
     steam_server_connect_failure_(this,
                                   &SteamClient::OnSteamServerConnectFailure),
+    gamepad_text_input_dismissed_(this,
+                                  &SteamClient::OnGamepadTextInputDismissed),
     steam_shutdown_(this, &SteamClient::OnSteamShutdown) {
 }
 
@@ -82,6 +84,14 @@ void SteamClient::OnSteamServerConnectFailure(
   for (size_t i = 0; i < observer_list_.size(); ++i) {
     observer_list_[i]->OnSteamServerConnectFailure(
         static_cast<int>(callback->m_eResult));
+  }
+}
+
+void SteamClient::OnGamepadTextInputDismissed(
+    GamepadTextInputDismissed_t* callback) {
+  for (size_t i = 0; i < observer_list_.size(); ++i) {
+    observer_list_[i]->OnGamepadTextInputDismissed(
+        callback->m_bSubmitted, callback->m_unSubmittedText);
   }
 }
 

--- a/src/steam_client.h
+++ b/src/steam_client.h
@@ -21,6 +21,7 @@ class SteamClient {
     virtual void OnSteamServersDisconnected() = 0;
     virtual void OnSteamServerConnectFailure(int status_code) = 0;
     virtual void OnSteamShutdown() = 0;
+    virtual void OnGamepadTextInputDismissed(bool submitted, uint32 text) = 0;
 
     virtual ~Observer() {}
   };
@@ -45,6 +46,8 @@ class SteamClient {
       SteamServersDisconnected_t, steam_servers_disconnected_);
   STEAM_CALLBACK(SteamClient, OnSteamServerConnectFailure,
       SteamServerConnectFailure_t, steam_server_connect_failure_);
+  STEAM_CALLBACK(SteamClient, OnGamepadTextInputDismissed,
+      GamepadTextInputDismissed_t, gamepad_text_input_dismissed_);
   STEAM_CALLBACK(SteamClient, OnSteamShutdown, SteamShutdown_t, steam_shutdown_);
 };
 


### PR DESCRIPTION
Fixes #60 

After discussing with @patrickklug, currenlyt we have no plan to support steam controller APIs since these APIs are too specific.

This PR exposes the Steam Big Picture APIs:

## greenworks.on("gamepad-text-input-dismissed", function(submitted, unsubmittedText) {})
  * submitted `Boolean`: true if user entered & accepted text (call `greenworks.getEnteredGamepadTextInput()` for text), false if canceled input.
  * unsubmittedText: `Integer`

Emits when Steam Big Picture gamepad text input has been closed.

## greenworks.showGamepadTextInput(inputMode, inputLineMode, description, charMax, existingText)
  * inputMode: `greenworks.GamepadTextInputMode`
  * inputLineMode: `greenworks.GamepadTextInputLineMode`
  * description: `String`
  * charMax: `Integer`
  * existingText: `String`

Activates the Big Picture text input dialog which only supports gamepad input

## greenworks.getEnteredGamepadTextLength()
Returns previously entered text's length

## greenworks.getEnteredGamepadTextInput(cchText)
  * cchText: `Integer`

Returns previously entered text

##Enum values:
* greenworks.GamepadTextInputMode.Normal
* greenworks.GamepadTextInputMode.Password
* greenworks.GamepadTextInputLineMode.SingleLine
* greenworks.GamepadTextInputLineMode.MultipleLines
