### PR TITLE
Improve init error handling

### DIFF
--- a/greenworks.js
+++ b/greenworks.js
@@ -96,6 +96,21 @@ greenworks.Utils.move = function(source_dir, target_dir, success_callback,
   });
 }
 
+greenworks.init = function() {
+  if (this.initAPI()) return;
+  if (!this.isSteamRunning()) throw new Error("Steam initialization failed. Steam is not running.");
+  var appId;
+  try {
+    appId = fs.readFileSync('steam_appid.txt', 'utf8');
+  } catch (e) {
+    throw new Error("Steam initialization failed. Steam is running, but steam_appid.txt is missing. Expected to find it in: " + require('path').resolve('steam_appid.txt'));
+  }
+  if (!/^\d+ *\r?\n?$/.test(appId)) {
+    throw new Error("Steam initialization failed. steam_appid.txt appears to be invalid; it should contain a numeric ID: " + appId);
+  }
+  throw new Error("Steam initialization failed, but Steam is running, and steam_appid.txt is present and valid. :shrug: Maybe that's not really YOUR app ID? " + appId.trim());
+}
+
 var EventEmitter = require('events').EventEmitter;
 greenworks.__proto__ = EventEmitter.prototype;
 EventEmitter.call(greenworks);

--- a/src/greenworks_api.cc
+++ b/src/greenworks_api.cc
@@ -144,6 +144,13 @@ NAN_METHOD(RestartAppIfNecessary) {
   info.GetReturnValue().Set(Nan::New(restarting));
 }
 
+NAN_METHOD(IsSteamRunning) {
+  Nan::HandleScope scope;
+
+  bool running = SteamAPI_IsSteamRunning();
+  info.GetReturnValue().Set(Nan::New(running));
+}
+
 NAN_METHOD(InitAPI) {
   Nan::HandleScope scope;
 
@@ -779,6 +786,9 @@ NAN_MODULE_INIT(init) {
   Nan::Set(target,
            Nan::New("restartAppIfNecessary").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(RestartAppIfNecessary)->GetFunction());
+  Nan::Set(target,
+           Nan::New("isSteamRunning").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(IsSteamRunning)->GetFunction());
   Nan::Set(target,
            Nan::New("getSteamId").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetSteamId)->GetFunction());


### PR DESCRIPTION
This adds a new `init()` function to greenworks, which throws an exception with a clear error message when initialization fails (by applying standard heuristics).

This required exposing `SteamAPI_IsSteamRunning()` which is super useful; it can return `true` even if your `steam_appid.txt` is missing. 