### PR TITLE
ISteamFriends getFriends()

### DIFF
--- a/src/greenworks_api.cc
+++ b/src/greenworks_api.cc
@@ -237,6 +237,9 @@ NAN_METHOD(GetSteamId) {
               GetSteamUserCountType(user_id.GetEAccountType()));
   result->Set(Nan::New("accountId").ToLocalChecked(),
               Nan::New<v8::Integer>(user_id.GetAccountID()));
+  result->Set(Nan::New("steamId").ToLocalChecked(),
+      Nan::New(utils::uint64ToString(
+          user_id.ConvertToUint64())).ToLocalChecked());
   result->Set(Nan::New("staticAccountId").ToLocalChecked(),
       Nan::New(utils::uint64ToString(
           user_id.GetStaticAccountKey())).ToLocalChecked());
@@ -308,6 +311,8 @@ NAN_METHOD(GetFriends) {
       aFriend->Set(Nan::New("type").ToLocalChecked(), GetSteamUserCountType(friendSteamID.GetEAccountType()));
       aFriend->Set(Nan::New("relationship").ToLocalChecked(), GetSteamFriendRelationship(SteamFriends()->GetFriendRelationship(friendSteamID)));
       aFriend->Set(Nan::New("accountId").ToLocalChecked(), Nan::New<v8::Integer>(friendSteamID.GetAccountID()));
+      aFriend->Set(Nan::New("steamId").ToLocalChecked(),
+          Nan::New(utils::uint64ToString(friendSteamID.ConvertToUint64())).ToLocalChecked());
       aFriend->Set(Nan::New("staticAccountId").ToLocalChecked(),
           Nan::New(utils::uint64ToString(friendSteamID.GetStaticAccountKey())).ToLocalChecked());
       aFriend->Set(Nan::New("isValid").ToLocalChecked(),

--- a/src/greenworks_api.cc
+++ b/src/greenworks_api.cc
@@ -51,7 +51,7 @@ void SteamEvent::OnSteamServersConnected() {
   v8::Local<v8::Value> argv[] = {
       Nan::New("steam-servers-connected").ToLocalChecked() };
   Nan::MakeCallback(
-      Nan::New(g_persistent_steam_events),"on", 1, argv);
+      Nan::New(g_persistent_steam_events), "on", 1, argv);
 }
 
 void SteamEvent::OnSteamServersDisconnected() {
@@ -281,45 +281,45 @@ NAN_METHOD(GetFriends) {
   int friendsCount = SteamFriends()->GetFriendCount(friend_flag);
   v8::Local<v8::Array> friends = Nan::New<v8::Array>();
 
-  for ( int i = 0; i < friendsCount; i++ ) {
-      CSteamID friendSteamID = SteamFriends()->GetFriendByIndex( i, friend_flag );
-      v8::Local<v8::Object> aFriend = Nan::New<v8::Object>();
-      v8::Local<v8::Object> flags = Nan::New<v8::Object>();
-      flags->Set(Nan::New("anonymous").ToLocalChecked(), Nan::New(friendSteamID.BAnonAccount()));
-      flags->Set(Nan::New("anonymousGameServer").ToLocalChecked(),
-          Nan::New(friendSteamID.BAnonGameServerAccount()));
-      flags->Set(Nan::New("anonymousGameServerLogin").ToLocalChecked(),
-          Nan::New(friendSteamID.BBlankAnonAccount()));
-      flags->Set(Nan::New("anonymousUser").ToLocalChecked(),
-                Nan::New(friendSteamID.BAnonUserAccount()));
-      flags->Set(Nan::New("chat").ToLocalChecked(),
-                Nan::New(friendSteamID.BChatAccount()));
-      flags->Set(Nan::New("clan").ToLocalChecked(),
-                Nan::New(friendSteamID.BClanAccount()));
-      flags->Set(Nan::New("consoleUser").ToLocalChecked(),
-                Nan::New(friendSteamID.BConsoleUserAccount()));
-      flags->Set(Nan::New("contentServer").ToLocalChecked(),
-                Nan::New(friendSteamID.BContentServerAccount()));
-      flags->Set(Nan::New("gameServer").ToLocalChecked(),
-                Nan::New(friendSteamID.BGameServerAccount()));
-      flags->Set(Nan::New("individual").ToLocalChecked(),
-                Nan::New(friendSteamID.BIndividualAccount()));
-      flags->Set(Nan::New("gameServerPersistent").ToLocalChecked(),
-                Nan::New(friendSteamID.BPersistentGameServerAccount()));
-      flags->Set(Nan::New("lobby").ToLocalChecked(), Nan::New(friendSteamID.IsLobby()));
-      aFriend->Set(Nan::New("flags").ToLocalChecked(), flags);
-      aFriend->Set(Nan::New("type").ToLocalChecked(), GetSteamUserCountType(friendSteamID.GetEAccountType()));
-      aFriend->Set(Nan::New("relationship").ToLocalChecked(), GetSteamFriendRelationship(SteamFriends()->GetFriendRelationship(friendSteamID)));
-      aFriend->Set(Nan::New("accountId").ToLocalChecked(), Nan::New<v8::Integer>(friendSteamID.GetAccountID()));
-      aFriend->Set(Nan::New("steamId").ToLocalChecked(),
-          Nan::New(utils::uint64ToString(friendSteamID.ConvertToUint64())).ToLocalChecked());
-      aFriend->Set(Nan::New("staticAccountId").ToLocalChecked(),
-          Nan::New(utils::uint64ToString(friendSteamID.GetStaticAccountKey())).ToLocalChecked());
-      aFriend->Set(Nan::New("isValid").ToLocalChecked(),
-          Nan::New<v8::Integer>(friendSteamID.IsValid()));
-      aFriend->Set(Nan::New("screenName").ToLocalChecked(),
-          Nan::New(SteamFriends()->GetFriendPersonaName(friendSteamID)).ToLocalChecked());
-      friends->Set(i, aFriend);
+  for (int i = 0; i < friendsCount; ++i) {
+    CSteamID friendSteamID = SteamFriends()->GetFriendByIndex(i, friend_flag);
+    v8::Local<v8::Object> aFriend = Nan::New<v8::Object>();
+    v8::Local<v8::Object> flags = Nan::New<v8::Object>();
+    flags->Set(Nan::New("anonymous").ToLocalChecked(), Nan::New(friendSteamID.BAnonAccount()));
+    flags->Set(Nan::New("anonymousGameServer").ToLocalChecked(),
+        Nan::New(friendSteamID.BAnonGameServerAccount()));
+    flags->Set(Nan::New("anonymousGameServerLogin").ToLocalChecked(),
+        Nan::New(friendSteamID.BBlankAnonAccount()));
+    flags->Set(Nan::New("anonymousUser").ToLocalChecked(),
+              Nan::New(friendSteamID.BAnonUserAccount()));
+    flags->Set(Nan::New("chat").ToLocalChecked(),
+              Nan::New(friendSteamID.BChatAccount()));
+    flags->Set(Nan::New("clan").ToLocalChecked(),
+              Nan::New(friendSteamID.BClanAccount()));
+    flags->Set(Nan::New("consoleUser").ToLocalChecked(),
+              Nan::New(friendSteamID.BConsoleUserAccount()));
+    flags->Set(Nan::New("contentServer").ToLocalChecked(),
+              Nan::New(friendSteamID.BContentServerAccount()));
+    flags->Set(Nan::New("gameServer").ToLocalChecked(),
+              Nan::New(friendSteamID.BGameServerAccount()));
+    flags->Set(Nan::New("individual").ToLocalChecked(),
+              Nan::New(friendSteamID.BIndividualAccount()));
+    flags->Set(Nan::New("gameServerPersistent").ToLocalChecked(),
+              Nan::New(friendSteamID.BPersistentGameServerAccount()));
+    flags->Set(Nan::New("lobby").ToLocalChecked(), Nan::New(friendSteamID.IsLobby()));
+    aFriend->Set(Nan::New("flags").ToLocalChecked(), flags);
+    aFriend->Set(Nan::New("type").ToLocalChecked(), GetSteamUserCountType(friendSteamID.GetEAccountType()));
+    aFriend->Set(Nan::New("relationship").ToLocalChecked(), GetSteamFriendRelationship(SteamFriends()->GetFriendRelationship(friendSteamID)));
+    aFriend->Set(Nan::New("accountId").ToLocalChecked(), Nan::New<v8::Integer>(friendSteamID.GetAccountID()));
+    aFriend->Set(Nan::New("steamId").ToLocalChecked(),
+        Nan::New(utils::uint64ToString(friendSteamID.ConvertToUint64())).ToLocalChecked());
+    aFriend->Set(Nan::New("staticAccountId").ToLocalChecked(),
+        Nan::New(utils::uint64ToString(friendSteamID.GetStaticAccountKey())).ToLocalChecked());
+    aFriend->Set(Nan::New("isValid").ToLocalChecked(),
+        Nan::New<v8::Integer>(friendSteamID.IsValid()));
+    aFriend->Set(Nan::New("screenName").ToLocalChecked(),
+        Nan::New(SteamFriends()->GetFriendPersonaName(friendSteamID)).ToLocalChecked());
+    friends->Set(i, aFriend);
   }
   info.GetReturnValue().Set(friends);
 }
@@ -901,7 +901,7 @@ NAN_MODULE_INIT(init) {
            Nan::New<v8::FunctionTemplate>(GetFriendCount)->GetFunction());
   Nan::Set(target,
            Nan::New("getFriends").ToLocalChecked(),
-           Nan::New<v8::FunctionTemplate>(GetFriends)->GetFunction());     
+           Nan::New<v8::FunctionTemplate>(GetFriends)->GetFunction());
   // File related APIs.
   Nan::Set(target,
            Nan::New("saveTextToFile").ToLocalChecked(),

--- a/src/greenworks_utils.cc
+++ b/src/greenworks_utils.cc
@@ -141,6 +141,41 @@ void InitUserUgcListSortOrder(v8::Handle<v8::Object> exports) {
            ugc_list_sort_order);
 }
 
+void InitFriendFlags(v8::Handle<v8::Object> exports) {
+  v8::Local<v8::Object> friend_flags = Nan::New<v8::Object>();
+  friend_flags->Set(Nan::New("None").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagNone));
+  friend_flags->Set(Nan::New("Blocked").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagBlocked));
+  friend_flags->Set(Nan::New("FriendshipRequested").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagFriendshipRequested));
+  friend_flags->Set(Nan::New("Immediate").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagImmediate));
+  friend_flags->Set(Nan::New("ClanMember").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagClanMember));
+  friend_flags->Set(Nan::New("OnGameServer").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagOnGameServer));
+  friend_flags->Set(Nan::New("RequestingFriendship").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagRequestingFriendship));
+  friend_flags->Set(Nan::New("RequestingInfo").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagRequestingInfo));
+  friend_flags->Set(Nan::New("Ignored").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagIgnored));
+  friend_flags->Set(Nan::New("IgnoredFriend").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagIgnoredFriend));
+  friend_flags->Set(Nan::New("Suggested").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagSuggested));
+  friend_flags->Set(Nan::New("ChatMember").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagChatMember));
+  friend_flags->Set(Nan::New("All").ToLocalChecked(),
+                         Nan::New(k_EFriendFlagAll));
+  Nan::Persistent<v8::Object> constructor;
+  constructor.Reset(friend_flags);
+  Nan::Set(exports,
+           Nan::New("FriendFlags").ToLocalChecked(),
+           friend_flags);
+}
+
 void sleep(int milliseconds) {
 #if defined(_WIN32)
   Sleep(milliseconds);

--- a/src/greenworks_utils.h
+++ b/src/greenworks_utils.h
@@ -21,6 +21,8 @@ void InitUserUgcListSortOrder(v8::Handle<v8::Object> exports);
 
 void InitUserUgcList(v8::Handle<v8::Object> exports);
 
+void InitFriendFlags(v8::Handle<v8::Object> exports);
+
 void sleep(int milliseconds);
 
 bool ReadFile(const char* path, char* &content, int& length);

--- a/test/test.js
+++ b/test/test.js
@@ -87,4 +87,14 @@ describe('greenworks API', function() {
       }, function(err) { throw err; done(); });
     });
   });
+
+  describe('getFriends', function() {
+    it('Should get successfully', function(done) {
+      assert(greenworks.FriendFlags);
+      assert(typeof greenworks.getFriendCount(greenworks.FriendFlags['All']), 'number');
+      assert(greenworks.getFriends(greenworks.FriendFlags['All']));
+      console.log(greenworks.getFriends(greenworks.FriendFlags['All']));
+      done();
+    });
+  });
 });


### PR DESCRIPTION
A `greenworks.getFriends()` method that returns an array containing your friends `accountId` and `screenName` using `ISteamFriends`. We are only retrieving `k_EFriendFlagImmediate` aka a `regular` friend (not pending, ignored, blocked, etc).

We use `SteamFriends()->RequestUserInformation(friendSteamID, true))` to get their `PersonaName` and set it to the `screenName` property. For whatever reason if this fails (not sure why it would), we use their `accountId` as `screenName` instead (same as in `getSteamId`).

Return array looks like: 
```
[ { accountId: 9420000, screenName: 'friend1' },
  { accountId: 3440000, screenName: 'friend2' },
  { accountId: 4810000, screenName: 'friend3' },
  { accountId: 4930000, screenName: 'friend4' }]
```
The `greenworks.getFriendCount()` just returns `ISteamFriends.getFriendCount()` and is not all that useful.