### PR TITLE
Add APIs for decrypting ticket

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,16 +12,22 @@
           'variables': {
             'project_name': 'greenworks-win32',
             'redist_bin_dir': '',
+            'public_lib_dir': 'win32',
             'lib_steam': 'steam_api.lib',
+            'lib_encryptedappticket': 'sdkencryptedappticket.lib',
             'lib_dll_steam': 'steam_api.dll',
+            'lib_dll_encryptedappticket': 'sdkencryptedappticket.dll',
           },
         }],
         ['target_arch=="x64"', {
           'variables': {
             'project_name': 'greenworks-win64',
             'redist_bin_dir': 'win64',
+            'public_lib_dir': 'win64',
             'lib_steam': 'steam_api64.lib',
+            'lib_encryptedappticket': 'sdkencryptedappticket64.lib',
             'lib_dll_steam': 'steam_api64.dll',
+            'lib_dll_encryptedappticket': 'sdkencryptedappticket64.dll',
           },
         }],
       ],
@@ -41,7 +47,9 @@
       ],
       'variables': {
         'redist_bin_dir': 'osx32',
-        'lib_steam': 'libsteam_api.dylib'
+        'public_lib_dir': 'osx32',
+        'lib_steam': 'libsteam_api.dylib',
+        'lib_encryptedappticket': 'libsdkencryptedappticket.dylib',
       },
     }],
     ['OS=="linux"', {
@@ -50,14 +58,18 @@
           'variables': {
             'project_name': 'greenworks-linux32',
             'redist_bin_dir': 'linux32',
-            'lib_steam': 'libsteam_api.so'
+            'public_lib_dir': 'linux32',
+            'lib_steam': 'libsteam_api.so',
+            'lib_encryptedappticket': 'libsdkencryptedappticket.so',
           }
         }],
         ['target_arch=="x64"', {
           'variables': {
             'project_name': 'greenworks-linux64',
             'redist_bin_dir': 'linux64',
-            'lib_steam': 'libsteam_api.so'
+            'public_lib_dir': 'linux64',
+            'lib_steam': 'libsteam_api.so',
+            'lib_encryptedappticket': 'libsdkencryptedappticket.so',
           }
         }],
       ],
@@ -106,7 +118,8 @@
       'dependencies': [ 'deps/zlib/zlib.gyp:minizip' ],
       'link_settings': {
         'libraries': [
-          '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_steam)'
+          '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_steam)',
+          '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_encryptedappticket)',
         ]
       },
       'cflags': [ '-std=c++11' ],
@@ -170,15 +183,18 @@
             'conditions': [
               ['OS=="win"', {
                 'lib_steam_path': '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_dll_steam)',
+                'lib_encryptedappticket_path': '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_dll_encryptedappticket)',
               }],
               ['OS=="mac" or OS=="linux"', {
                 'lib_steam_path': '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_steam)',
+                'lib_encryptedappticket_path': '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_encryptedappticket)',
               }],
             ]
           },
           'inputs': [
             '<(lib_steam_path)',
-            '<(PRODUCT_DIR)/<(project_name).node'
+            '<(lib_encryptedappticket_path)',
+            '<(PRODUCT_DIR)/<(project_name).node',
           ],
           'outputs': [
             '<(target_dir)',

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -6,7 +6,6 @@
   * `ticket` Object:
     * `ticket` Buffer:  The `ticket` value.
     * `handle` Integer: The `handle` value returned from the ticket.
-  The handle is needed to inva
 * `error_callback` Function(err)
 
 Retrieve ticket to be sent to the entity who wishes to authenticate you.
@@ -26,8 +25,8 @@ Invalidates a requested session ticket.
 
 * `user_data` String: Arbitrary data that will be encrypted into the ticket.
   This will be utf-8 encoded when stored in the ticket.
-* `success_callback` Function(ticket)
-  * `ticket` Buffer: The encrypted ticket.
+* `success_callback` Function(encrypted_ticket)
+  * `encrypted_ticket` Buffer: The encrypted ticket.
 * `error_callback` Function(err)
 
 Encrypted tickets can be used to obtain authenticated Steam IDs from clients
@@ -35,3 +34,37 @@ without requiring network requests to Steam's API servers. These tickets can be
 decrypted using your Encrypted App Ticket Key. Once decrypted, the user's
 Steam ID, App ID, and VAC ban status can be read from the ticket using the
 Steamworks Encrypted App Ticket library provided in the SDK.
+
+### greenworks.decryptAppTicket(encrypted_ticket, decryption_key)
+
+* `encrypted_ticket` Buffer: The encrypted ticket.
+* `decryption_key` Buffer: The secret key for decryption.
+
+Decrypt the encrypted app ticket with your decryption key. Returns a `Buffer`
+represents the decrypted ticket if succeeds; otherwise returns a `Null`.
+
+### greenworks.isTicketForApp(decrypted_ticket, app_id)
+
+* `decrypted_ticket` Buffer: The decrypted ticket.
+* `app_id` Integer: The id for the app.
+
+Returns a `Boolean` indicates whether the decrypted ticket is for the app.
+
+### greenworks.getTicketIssueTime(decrypted_ticket)
+
+* `decrypted_ticket` Buffer: The decrypted ticket.
+
+Returns an `Integer` represents the ticket issue time.
+
+### greenworks.getTicketSteamId(decrypted_ticket)
+
+* `decrypted_ticket` Buffer: The decrypted ticket.
+
+Returns an [`SteamID`](friends.md#steamid) object represents the steam id of the
+ticket.
+
+### greenworks.getTicketAppId(decrypted_ticket)
+
+* `decrypted_ticket` Buffer: The decrypted ticket.
+
+Returns an `Integer` represents app id of the ticket.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -3,6 +3,11 @@
 Authentication APIs provide utilities to authenticate a Steam user's identity
 and verify ownership of an application.
 
+**Note:** Authentication APIs are required an extra dynamic library. Please copy
+`sdkencryptedappticket.dll`/`libsdkencryptedappticket.dylib`/`libsdkencryptedappticket.so`
+from Steamworks SDK (`<steam_sdk-path>/public/steam/lib/`) to your application
+directory `<greenworks>/lib`.
+
 ```javascript
 var greenworks = require('./greenworks');
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,3 +1,29 @@
+# Authentication
+
+Authentication APIs provide utilities to authenticate a Steam user's identity
+and verify ownership of an application.
+
+```javascript
+var greenworks = require('./greenworks');
+
+greenworks.init();
+
+greenworks.getEncryptedAppTicket('test_content', function(ticket) {
+  console.log("ticket: " + ticket.toString('hex'));
+  // Specify the secret key.
+  var key = new Buffer(32);
+  assert(key.length == greenworks.EncryptedAppTicketSymmetricKeyLength)
+  var decrypted_app_ticket = greenworks.decryptAppTicket(ticket, key);
+  if (decrypted_app_ticket) {
+    console.log(greenworks.isTicketForApp(decrypted_app_ticket,
+                greenworks.getAppId()));
+    console.log(greenworks.getTicketAppId(decrypted_app_ticket));
+    console.log(greenworks.getTicketSteamId(decrypted_app_ticket));
+    console.log(greenworks.getTicketIssueTime(decrypted_app_ticket));
+  }
+}, function(err) { throw err; });
+```
+
 ## Methods
 
 ### greenworks.getAuthSessionTicket(success_callback, [error_callback])
@@ -38,7 +64,8 @@ Steamworks Encrypted App Ticket library provided in the SDK.
 ### greenworks.decryptAppTicket(encrypted_ticket, decryption_key)
 
 * `encrypted_ticket` Buffer: The encrypted ticket.
-* `decryption_key` Buffer: The secret key for decryption.
+* `decryption_key` Buffer: The secret key for decryption. The length of the key
+  should be `greenworks.EncryptedAppTicketSymmetricKeyLength`.
 
 Decrypt the encrypted app ticket with your decryption key. Returns a `Buffer`
 represents the decrypted ticket if succeeds; otherwise returns a `Null`.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -3,11 +3,15 @@
 ### greenworks.getAuthSessionTicket(success_callback, [error_callback])
 
 * `success_callback` Function(ticket)
-  * `ticket` Object: Contains the hex encoded session `ticket` value as well as
-    the `handle` integer value.
+  * `ticket` Object:
+    * `ticket` Buffer:  The `ticket` value.
+    * `handle` Integer: The `handle` value returned from the ticket.
+  The handle is needed to inva
 * `error_callback` Function(err)
 
-The hex encoded `ticket` value can be used directly for the Web API
+Retrieve ticket to be sent to the entity who wishes to authenticate you.
+
+The `ticket` buffer can be used like `ticket.toString('hex')` for the Web API
 `ISteamUserAuth/AuthenticateUserTicket` to securely obtain an authenticated
 Steam ID from your game server. The `handle` is needed to invalidate the ticket
 after if it has not been used.
@@ -23,7 +27,7 @@ Invalidates a requested session ticket.
 * `user_data` String: Arbitrary data that will be encrypted into the ticket.
   This will be utf-8 encoded when stored in the ticket.
 * `success_callback` Function(ticket)
-  * `ticket` String: Contains the hex encoded encrypted ticket.
+  * `ticket` Buffer: The encrypted ticket.
 * `error_callback` Function(err)
 
 Encrypted tickets can be used to obtain authenticated Steam IDs from clients

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -26,6 +26,10 @@ app, and then cause your app to quit.
 There's not a moment to lose after you call `restartAppIfNecessary()`, but if
 it returns `true`, your app is being restarted.
 
+### greenworks.getAppId()
+
+Returns an `Integer` represents the app id of the current process.
+
 ### greenworks.getSteamId()
 
 Returns an [`SteamID`](friends.md#steamid) object represents the current Steam

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,11 @@ developing. If you launch the game from Steam, Steam will automatically know the
 APP ID of your game.)
 4. Create your NW.js app code under `<greenworks_path>/` directory.
 
+Optional: If you use [Authentication APIs](docs/authentication.md), you also
+need to copy `sdkencryptedappticket.dll`/`libsdkencryptedappticket.dylib`/
+`libsdkencryptedappticket.so` from Steamworks SDK (`<steam_sdk-path>/public/steam/lib/`)
+to `<greenworks_path>/lib`.
+
 **A hello-world sample**
 
 Create `index.html`:

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -9,6 +9,7 @@
 
 #include "greenworks_async_workers.h"
 #include "steam_api_registry.h"
+#include "steam_id.h"
 
 namespace greenworks {
 namespace api {
@@ -120,6 +121,20 @@ NAN_METHOD(getTicketIssueTime) {
   info.GetReturnValue().Set(time);
 }
 
+NAN_METHOD(getTicketSteamId) {
+  Nan::HandleScope scope;
+  if (info.Length() < 1 || !node::Buffer::HasInstance(info[0])) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+  char* decrypted_ticket_buf = node::Buffer::Data(info[0]);
+  size_t decrypted_ticket_buf_size = node::Buffer::Length(info[0]);
+  CSteamID steam_id;
+  SteamEncryptedAppTicket_GetTicketSteamID(
+      reinterpret_cast<uint8*>(decrypted_ticket_buf), decrypted_ticket_buf_size,
+      &steam_id);
+  info.GetReturnValue().Set(greenworks::SteamID::Create(steam_id));
+}
+
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("getAuthSessionTicket").ToLocalChecked(),
@@ -140,6 +155,10 @@ void RegisterAPIs(v8::Handle<v8::Object> target) {
            Nan::New("getTicketIssueTime").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(
                getTicketIssueTime)->GetFunction());
+  Nan::Set(target,
+           Nan::New("getTicketSteamId").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(
+               getTicketSteamId)->GetFunction());
   Nan::Set(target,
            Nan::New("cancelAuthTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(CancelAuthTicket)->GetFunction());

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -107,6 +107,19 @@ NAN_METHOD(IsTicketForApp) {
   info.GetReturnValue().Set(result);
 }
 
+NAN_METHOD(getTicketIssueTime) {
+  Nan::HandleScope scope;
+  if (info.Length() < 1 || !node::Buffer::HasInstance(info[0])) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+  char* decrypted_ticket_buf = node::Buffer::Data(info[0]);
+  size_t decrypted_ticket_buf_size = node::Buffer::Length(info[0]);
+  uint32 time = SteamEncryptedAppTicket_GetTicketIssueTime(
+      reinterpret_cast<uint8*>(decrypted_ticket_buf),
+      decrypted_ticket_buf_size);
+  info.GetReturnValue().Set(time);
+}
+
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("getAuthSessionTicket").ToLocalChecked(),
@@ -123,6 +136,10 @@ void RegisterAPIs(v8::Handle<v8::Object> target) {
            Nan::New("isTicketForApp").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(
                IsTicketForApp)->GetFunction());
+  Nan::Set(target,
+           Nan::New("getTicketIssueTime").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(
+               getTicketIssueTime)->GetFunction());
   Nan::Set(target,
            Nan::New("cancelAuthTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(CancelAuthTicket)->GetFunction());

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -95,7 +95,7 @@ NAN_METHOD(DecryptAppTicket) {
 NAN_METHOD(IsTicketForApp) {
   Nan::HandleScope scope;
   if (info.Length() < 2 || !node::Buffer::HasInstance(info[0]) ||
-      info[1]->IsUint32()) {
+      !info[1]->IsUint32()) {
     THROW_BAD_ARGS("Bad arguments");
   }
 

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -135,6 +135,19 @@ NAN_METHOD(getTicketSteamId) {
   info.GetReturnValue().Set(greenworks::SteamID::Create(steam_id));
 }
 
+NAN_METHOD(getTicketAppId) {
+  Nan::HandleScope scope;
+  if (info.Length() < 1 || !node::Buffer::HasInstance(info[0])) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+  char* decrypted_ticket_buf = node::Buffer::Data(info[0]);
+  size_t decrypted_ticket_buf_size = node::Buffer::Length(info[0]);
+  uint32 app_id = SteamEncryptedAppTicket_GetTicketAppID(
+      reinterpret_cast<uint8*>(decrypted_ticket_buf),
+      decrypted_ticket_buf_size);
+  info.GetReturnValue().Set(app_id);
+}
+
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("getAuthSessionTicket").ToLocalChecked(),
@@ -159,6 +172,10 @@ void RegisterAPIs(v8::Handle<v8::Object> target) {
            Nan::New("getTicketSteamId").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(
                getTicketSteamId)->GetFunction());
+  Nan::Set(target,
+           Nan::New("getTicketAppId").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(
+               getTicketAppId)->GetFunction());
   Nan::Set(target,
            Nan::New("cancelAuthTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(CancelAuthTicket)->GetFunction());

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -91,6 +91,22 @@ NAN_METHOD(DecryptAppTicket) {
           .ToLocalChecked());
 }
 
+NAN_METHOD(IsTicketForApp) {
+  Nan::HandleScope scope;
+  if (info.Length() < 2 || !node::Buffer::HasInstance(info[0]) ||
+      info[1]->IsUint32()) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+
+  char* decrypted_ticket_buf = node::Buffer::Data(info[0]);
+  size_t decrypted_ticket_buf_size = node::Buffer::Length(info[0]);
+  uint32 app_id = info[1]->Uint32Value();
+  bool result = SteamEncryptedAppTicket_BIsTicketForApp(
+      reinterpret_cast<uint8*>(decrypted_ticket_buf), decrypted_ticket_buf_size,
+      app_id);
+  info.GetReturnValue().Set(result);
+}
+
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("getAuthSessionTicket").ToLocalChecked(),
@@ -103,6 +119,10 @@ void RegisterAPIs(v8::Handle<v8::Object> target) {
            Nan::New("decryptAppTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(
                DecryptAppTicket)->GetFunction());
+  Nan::Set(target,
+           Nan::New("isTicketForApp").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(
+               IsTicketForApp)->GetFunction());
   Nan::Set(target,
            Nan::New("cancelAuthTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(CancelAuthTicket)->GetFunction());

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -150,6 +150,9 @@ NAN_METHOD(getTicketAppId) {
 
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
+           Nan::New("EncryptedAppTicketSymmetricKeyLength").ToLocalChecked(),
+           Nan::New(k_nSteamEncryptedAppTicketSymmetricKeyLen));
+  Nan::Set(target,
            Nan::New("getAuthSessionTicket").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetAuthSessionTicket)->GetFunction());
   Nan::Set(target,

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -141,6 +141,12 @@ NAN_METHOD(GetSteamId) {
   info.GetReturnValue().Set(result);
 }
 
+NAN_METHOD(GetAppId) {
+  Nan::HandleScope scope;
+  info.GetReturnValue().Set(
+      Nan::New(SteamUtils()->GetAppID()));
+}
+
 NAN_METHOD(GetCurrentGameLanguage) {
   Nan::HandleScope scope;
   info.GetReturnValue().Set(
@@ -272,6 +278,9 @@ void RegisterAPIs(v8::Handle<v8::Object> exports) {
   Nan::Set(exports,
            Nan::New("getSteamId").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetSteamId)->GetFunction());
+  Nan::Set(exports,
+           Nan::New("getAppId").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(GetAppId)->GetFunction());
   Nan::Set(exports,
            Nan::New("getCurrentGameLanguage").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(

--- a/src/greenworks_async_workers.h
+++ b/src/greenworks_async_workers.h
@@ -174,10 +174,9 @@ class GetAuthSessionTicketWorker : public SteamCallbackAsyncWorker {
   virtual void HandleOKCallback();
 
  private:
-  std::string ticket_;
   HAuthTicket handle_;
   unsigned int ticket_buf_size_;
-  unsigned char ticket_buf_[2048];
+  uint8 ticket_buf_[2048];
 };
 
 class RequestEncryptedAppTicketWorker : public SteamCallbackAsyncWorker {
@@ -192,9 +191,8 @@ class RequestEncryptedAppTicketWorker : public SteamCallbackAsyncWorker {
 
  private:
   std::string user_data_;
-  std::string ticket_;
   unsigned int ticket_buf_size_;
-  unsigned char ticket_buf_[4096];
+  uint8 ticket_buf_[4096];
   CCallResult< RequestEncryptedAppTicketWorker, EncryptedAppTicketResponse_t >
       call_result_;
 };

--- a/tools/copy_binaries.py
+++ b/tools/copy_binaries.py
@@ -5,12 +5,9 @@ import shutil
 import stat
 import sys
 
-lib_steam_file = sys.argv[1]
-greenworks_node_file = sys.argv[2];
-target_dir = sys.argv[3];
-
+target_dir = sys.argv[-1]
 if not os.path.exists(target_dir):
   os.mkdir(target_dir)
 
-shutil.copy(lib_steam_file, target_dir)
-shutil.copy(greenworks_node_file, target_dir)
+for argv in sys.argv[:-1]:
+  shutil.copy(argv, target_dir)


### PR DESCRIPTION
Fixes #93.

@jahrain : I also made some changes in `getAuthSessionTicket` and `get getEncryptedAppTicket`, Now the `Ticket` is returned as a `node::Buffer` instead of a hex-hardcoded `String`.
 
cc @artch