### PR TITLE
Fix ugcGetItems returns empty array.

### DIFF
--- a/src/greenworks_workshop_workers.cc
+++ b/src/greenworks_workshop_workers.cc
@@ -280,8 +280,12 @@ QueryAllUGCWorker::QueryAllUGCWorker(Nan::Callback* success_callback,
 
 void QueryAllUGCWorker::Execute() {
   uint32 app_id = SteamUtils()->GetAppID();
+  uint32 invalid_app_id = 0;
+  // Set "creator_app_id" parameter to an invalid id to make Steam API return
+  // all ugc items, otherwise the API won't get any results in some cases.
   UGCQueryHandle_t ugc_handle = SteamUGC()->CreateQueryAllUGCRequest(
-      ugc_query_type_, ugc_matching_type_, app_id, app_id, 1);
+      ugc_query_type_, ugc_matching_type_, /*creator_app_id=*/invalid_app_id,
+      /*consumer_app_id=*/app_id, 1);
   SteamAPICall_t ugc_query_result = SteamUGC()->SendQueryUGCRequest(ugc_handle);
   ugc_query_call_result_.Set(ugc_query_result, this,
       &QueryAllUGCWorker::OnUGCQueryCompleted);


### PR DESCRIPTION
I could not find more details about creator app id and consumer app id in `CreateQueryAllUGCRequest` API, except for the code comment

> Creator app id or consumer app id must be valid and be set to the current running app. 

* Before the change: the API won't return any results for some games (e.g. [219740](https://steamcommunity.com/workshop/browse/?appid=219740), [322330](https://steamcommunity.com/workshop/browse/?appid=322330)), but it work for games like [239820](https://steamcommunity.com/workshop/browse/?appid=239820)
* After the change: the API works for all my tested games

So the PR should fix #137. 
