### PR TITLE
Support STEAMWORKS_SDK_PATH env var

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,6 @@
 {
   'variables': {
-    'source_root_dir': '<!(python tools/source_root_dir.py)',
-    'steamworks_sdk_dir': 'deps/steamworks_sdk',
+    'steamworks_sdk_dir': '<!(node tools/steamworks_sdk_dir.js)',
     'target_dir': 'lib'
   },
 
@@ -120,8 +119,8 @@
       'dependencies': [ 'deps/zlib/zlib.gyp:minizip' ],
       'link_settings': {
         'library_dirs': [
-          '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/',
-          '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/',
+          '<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/',
+          '<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/',
         ],
         'conditions': [
           ['OS=="linux" or OS=="mac"', {
@@ -192,12 +191,12 @@
           'variables': {
             'conditions': [
               ['OS=="win"', {
-                'lib_steam_path': '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_dll_steam)',
-                'lib_encryptedappticket_path': '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_dll_encryptedappticket)',
+                'lib_steam_path': '<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_dll_steam)',
+                'lib_encryptedappticket_path': '<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_dll_encryptedappticket)',
               }],
               ['OS=="mac" or OS=="linux"', {
-                'lib_steam_path': '<(source_root_dir)/<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_steam)',
-                'lib_encryptedappticket_path': '<(source_root_dir)/<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_encryptedappticket)',
+                'lib_steam_path': '<(steamworks_sdk_dir)/redistributable_bin/<(redist_bin_dir)/<(lib_steam)',
+                'lib_encryptedappticket_path': '<(steamworks_sdk_dir)/public/steam/lib/<(public_lib_dir)/<(lib_encryptedappticket)',
               }],
             ]
           },

--- a/docs/get-steamworks-sdk.md
+++ b/docs/get-steamworks-sdk.md
@@ -17,3 +17,5 @@ downloads list.)
 3. The extracted contents will contain one subdirectory, `sdk`. Rename it to
 `steamworks_sdk`.
 4. Copy the renamed directory `steamworks_sdk` to `<greenworks_src_dir>/deps/`.
+Alternatively, you can also set a `STEAMWORKS_SDK_PATH` environment variable which points to the `steamworks_sdk` directory.
+

--- a/tools/source_root_dir.py
+++ b/tools/source_root_dir.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-import os
-
-"""Prints the absolute path of the root of source tree.
-"""
-print os.path.abspath(os.path.dirname(os.path.dirname(__file__)))

--- a/tools/steamworks_sdk_dir.js
+++ b/tools/steamworks_sdk_dir.js
@@ -1,0 +1,14 @@
+/* global console, require, __dirname, process */
+'use strict';
+
+const path = require('path');
+
+// Allow setting a different steamworks_sdk path via an environment variable
+if (process.env.STEAMWORKS_SDK_PATH) {
+    console.log(process.env.STEAMWORKS_SDK_PATH);
+}
+
+// Otherwise, use the default path (deps/steamworks_sdk)
+else {
+    console.log(path.join(__dirname, '..', 'deps', 'steamworks_sdk'));
+}


### PR DESCRIPTION
I found that copying the steamworks sdk to `node_modules/greenworks/deps/steamworks_sdk`  caused some issues.
Certain `npm`/`yarn` operations would reset the `node_modules/greenworks` folder, requiring re-copying the sdk, which is an annoyance.

This PR adds support for a `STEAMWORKS_SDK_PATH` environment variable which allows setting a different path to the steamworks sdk folder (other than default `deps/steamworks_sdk`).
