### PR TITLE
Feature/unpage items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 2018.01.28 v0.12.1 stable
+
+* Updated `ugcGetItems` & `ugcGetUserItems` APIs to query specific pages:
+
+  * `greenworks.ugcGetItems(ugc_matching_type, ugc_query_type, unPage, success_callback, [error_callback])`
+
+  * `greenworks.ugcGetUserItems(ugc_matching_type, ugc_list_sort_order, ugc_list, unPage, success_callback, [error_callback])`
+
+
 ## 2017.12.02 v0.12.0 stable
 
 * Greenworks complied for NW.js v0.24.4, v0.25.4 & v0.26.6 with Steamworks SDK 1.41

--- a/docs/workshop.md
+++ b/docs/workshop.md
@@ -163,19 +163,21 @@ Publishes user generated content(ugc) to Steam workshop.
 
 Updates published ugc.
 
-### greenworks.ugcGetItems(ugc_matching_type, ugc_query_type, success_callback, [error_callback])
+### greenworks.ugcGetItems(ugc_matching_type, ugc_query_type, unPage, success_callback, [error_callback])
 
 * `ugc_matching_type` greenworks.UGCMatchingType
 * `ugc_query_type` greenworks.UGCQueryType
+* `unPage` Integer: The page number of the results to receive
 * `success_callback` Function(items)
   * `items` Array of `SteamUGCDetails` Object
 * `error_callback` Function(err)
 
-### greenworks.ugcGetUserItems(ugc_matching_type, ugc_list_sort_order, ugc_list, success_callback, [error_callback])
+### greenworks.ugcGetUserItems(ugc_matching_type, ugc_list_sort_order, ugc_list, unPage, success_callback, [error_callback])
 
 * `ugc_matching_type` greenworks.UGCMatchingType
 * `ugc_list_sort_order` greenworks.UserUGCListSortOrder
 * `ugc_list` greenworks.UserUGCList
+* `unPage` Integer: The page number of the results to receive
 * `success_callback` Function(items)
   * `items` Array of `SteamUGCDetails` Object
 * `error_callback` Function(err)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "greenworks",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A node.js addon exposing Valve's Steamworks APIs to JavaScript",
   "licenses": [
     {

--- a/src/api/steam_api_workshop.cc
+++ b/src/api/steam_api_workshop.cc
@@ -180,8 +180,8 @@ NAN_METHOD(UpdatePublishedWorkshopFile) {
 
 NAN_METHOD(UGCGetItems) {
   Nan::HandleScope scope;
-  if (info.Length() < 3 || !info[0]->IsInt32() || !info[1]->IsInt32() ||
-      !info[2]->IsFunction()) {
+  if (info.Length() < 4 || !info[0]->IsInt32() || !info[1]->IsInt32() ||
+    !info[2]->IsInt32() || !info[3]->IsFunction()) {
     THROW_BAD_ARGS("Bad arguments");
   }
 
@@ -189,30 +189,10 @@ NAN_METHOD(UGCGetItems) {
       info[0]->Int32Value());
   EUGCQuery ugc_query_type = static_cast<EUGCQuery>(info[1]->Int32Value());
 
-  Nan::Callback* success_callback =
-      new Nan::Callback(info[2].As<v8::Function>());
-  Nan::Callback* error_callback = NULL;
-
-  if (info.Length() > 3 && info[3]->IsFunction())
-    error_callback = new Nan::Callback(info[3].As<v8::Function>());
-
-  Nan::AsyncQueueWorker(new greenworks::QueryAllUGCWorker(
-      success_callback, error_callback, ugc_matching_type, ugc_query_type));
-  info.GetReturnValue().Set(Nan::Undefined());
-}
-
-NAN_METHOD(UGCGetUserItems) {
-  Nan::HandleScope scope;
-  if (info.Length() < 4 || !info[0]->IsInt32() || !info[1]->IsInt32() ||
-      !info[2]->IsInt32() || !info[3]->IsFunction()) {
-    THROW_BAD_ARGS("Bad arguments");
+  uint32 unPage = info[2]->Int32Value();
+  if(unPage < 1) {
+    THROW_BAD_ARGS("unPage must be atleast 1!");
   }
-
-  EUGCMatchingUGCType ugc_matching_type = static_cast<EUGCMatchingUGCType>(
-      info[0]->Int32Value());
-  EUserUGCListSortOrder ugc_list_order = static_cast<EUserUGCListSortOrder>(
-      info[1]->Int32Value());
-  EUserUGCList ugc_list = static_cast<EUserUGCList>(info[2]->Int32Value());
 
   Nan::Callback* success_callback =
       new Nan::Callback(info[3].As<v8::Function>());
@@ -221,9 +201,40 @@ NAN_METHOD(UGCGetUserItems) {
   if (info.Length() > 4 && info[4]->IsFunction())
     error_callback = new Nan::Callback(info[4].As<v8::Function>());
 
+  Nan::AsyncQueueWorker(new greenworks::QueryAllUGCWorker(
+      success_callback, error_callback, ugc_matching_type, ugc_query_type,
+      unPage));
+  info.GetReturnValue().Set(Nan::Undefined());
+}
+
+NAN_METHOD(UGCGetUserItems) {
+  Nan::HandleScope scope;
+  if (info.Length() < 5 || !info[0]->IsInt32() || !info[1]->IsInt32() ||
+      !info[2]->IsInt32() || !info[3]->IsInt32() || !info[4]->IsFunction()) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+
+  EUGCMatchingUGCType ugc_matching_type = static_cast<EUGCMatchingUGCType>(
+      info[0]->Int32Value());
+  EUserUGCListSortOrder ugc_list_order = static_cast<EUserUGCListSortOrder>(
+      info[1]->Int32Value());
+  EUserUGCList ugc_list = static_cast<EUserUGCList>(info[2]->Int32Value());
+  
+  uint32 unPage = info[3]->Int32Value();
+  if(unPage < 1) {
+    THROW_BAD_ARGS("unPage must be atleast 1!");
+  }
+
+  Nan::Callback* success_callback =
+      new Nan::Callback(info[4].As<v8::Function>());
+  Nan::Callback* error_callback = NULL;
+
+  if (info.Length() > 5 && info[5]->IsFunction())
+    error_callback = new Nan::Callback(info[5].As<v8::Function>());
+
   Nan::AsyncQueueWorker(new greenworks::QueryUserUGCWorker(
       success_callback, error_callback, ugc_matching_type, ugc_list,
-      ugc_list_order));
+      ugc_list_order, unPage));
   info.GetReturnValue().Set(Nan::Undefined());
 }
 

--- a/src/greenworks_workshop_workers.cc
+++ b/src/greenworks_workshop_workers.cc
@@ -273,9 +273,10 @@ void QueryUGCWorker::OnUGCQueryCompleted(SteamUGCQueryCompleted_t* result,
 
 QueryAllUGCWorker::QueryAllUGCWorker(Nan::Callback* success_callback,
     Nan::Callback* error_callback, EUGCMatchingUGCType ugc_matching_type,
-    EUGCQuery ugc_query_type)
+    EUGCQuery ugc_query_type, uint32 unPage)
         :QueryUGCWorker(success_callback, error_callback, ugc_matching_type),
-         ugc_query_type_(ugc_query_type) {
+         ugc_query_type_(ugc_query_type),
+         unPage_(unPage) {
 }
 
 void QueryAllUGCWorker::Execute() {
@@ -285,7 +286,7 @@ void QueryAllUGCWorker::Execute() {
   // all ugc items, otherwise the API won't get any results in some cases.
   UGCQueryHandle_t ugc_handle = SteamUGC()->CreateQueryAllUGCRequest(
       ugc_query_type_, ugc_matching_type_, /*creator_app_id=*/invalid_app_id,
-      /*consumer_app_id=*/app_id, 1);
+      /*consumer_app_id=*/app_id, unPage_);
   SteamAPICall_t ugc_query_result = SteamUGC()->SendQueryUGCRequest(ugc_handle);
   ugc_query_call_result_.Set(ugc_query_result, this,
       &QueryAllUGCWorker::OnUGCQueryCompleted);
@@ -296,10 +297,12 @@ void QueryAllUGCWorker::Execute() {
 
 QueryUserUGCWorker::QueryUserUGCWorker(Nan::Callback* success_callback,
     Nan::Callback* error_callback, EUGCMatchingUGCType ugc_matching_type,
-    EUserUGCList ugc_list, EUserUGCListSortOrder ugc_list_sort_order)
+    EUserUGCList ugc_list, EUserUGCListSortOrder ugc_list_sort_order,
+    uint32 unPage)
         :QueryUGCWorker(success_callback, error_callback, ugc_matching_type),
          ugc_list_(ugc_list),
-         ugc_list_sort_order_(ugc_list_sort_order) {
+         ugc_list_sort_order_(ugc_list_sort_order),
+         unPage_(unPage) {
 }
 
 void QueryUserUGCWorker::Execute() {
@@ -312,7 +315,7 @@ void QueryUserUGCWorker::Execute() {
       ugc_list_sort_order_,
       app_id,
       app_id,
-      1);
+      unPage_);
   SteamAPICall_t ugc_query_result = SteamUGC()->SendQueryUGCRequest(ugc_handle);
   ugc_query_call_result_.Set(ugc_query_result, this,
       &QueryUserUGCWorker::OnUGCQueryCompleted);

--- a/src/greenworks_workshop_workers.h
+++ b/src/greenworks_workshop_workers.h
@@ -109,13 +109,15 @@ class QueryAllUGCWorker : public QueryUGCWorker {
   QueryAllUGCWorker(Nan::Callback* success_callback,
                     Nan::Callback* error_callback,
                     EUGCMatchingUGCType ugc_matching_type,
-                    EUGCQuery ugc_query_type);
+                    EUGCQuery ugc_query_type,
+                    uint32 unPage);
 
   // Override Nan::AsyncWorker methods.
   virtual void Execute();
 
  private:
   EUGCQuery ugc_query_type_;
+  uint32 unPage_;
 };
 
 class QueryUserUGCWorker : public QueryUGCWorker {
@@ -124,7 +126,8 @@ class QueryUserUGCWorker : public QueryUGCWorker {
                      Nan::Callback* error_callback,
                      EUGCMatchingUGCType ugc_matching_type,
                      EUserUGCList ugc_list,
-                     EUserUGCListSortOrder ugc_list_sort_order);
+                     EUserUGCListSortOrder ugc_list_sort_order,
+                     uint32 unPage);
 
   // Override Nan::AsyncWorker methods.
   virtual void Execute();
@@ -132,6 +135,7 @@ class QueryUserUGCWorker : public QueryUGCWorker {
  private:
   EUserUGCList ugc_list_;
   EUserUGCListSortOrder ugc_list_sort_order_;
+  uint32 unPage_;
 };
 
 class DownloadItemWorker : public SteamCallbackAsyncWorker {


### PR DESCRIPTION
Ability to issue the page number of the results to receive, as described in the official API documents:
https://partner.steamgames.com/doc/api/ISteamUGC#CreateQueryAllUGCRequest

Methods that have been changed:

  * `greenworks.ugcGetItems(ugc_matching_type, ugc_query_type, unPage, success_callback, [error_callback])`

  * `greenworks.ugcGetUserItems(ugc_matching_type, ugc_list_sort_order, ugc_list, unPage, success_callback, [error_callback])`