### PR TITLE
APIs for enumerating files on cloud

### DIFF
--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -54,3 +54,16 @@ app won't sync anything to the user's cloud if he disabled it at top level
   * `total_bytes` uint64 String: total bytes of quota
   * `available_bytes` uint64 String: available bytes of quota
 * `error_callback` Function(err)
+
+### greenworks.getFileCount()
+
+Gets the number of files on the cloud.
+
+### greenworks.getFileNameAndSize(index)
+
+* `index` Integer: the index of the file
+
+Returns an `Object`:
+
+* `name` String: The file name
+* `size` Integer: The file size

--- a/src/api/steam_api_cloud.cc
+++ b/src/api/steam_api_cloud.cc
@@ -152,6 +152,27 @@ NAN_METHOD(GetCloudQuota) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
+NAN_METHOD(GetFileCount) {
+  Nan::HandleScope scope;
+  info.GetReturnValue().Set(SteamRemoteStorage()->GetFileCount());
+}
+
+NAN_METHOD(GetFileNameAndSize) {
+  v8::Local<v8::Object> result = Nan::New<v8::Object>();
+  if (info.Length() < 1 || !info[0]->IsInt32()) {
+    THROW_BAD_ARGS("Bad arguments");
+  }
+  int32 index = info[0].As<v8::Number>()->Int32Value();
+  int32 file_size;
+  const char* file_name =
+      SteamRemoteStorage()->GetFileNameAndSize(index, &file_size);
+  result->Set(Nan::New("name").ToLocalChecked(),
+              Nan::New(file_name).ToLocalChecked());
+  result->Set(Nan::New("size").ToLocalChecked(),
+              Nan::New(file_size));
+  info.GetReturnValue().Set(result);
+}
+
 void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("saveTextToFile").ToLocalChecked(),
@@ -178,6 +199,12 @@ void RegisterAPIs(v8::Handle<v8::Object> target) {
   Nan::Set(target,
            Nan::New("getCloudQuota").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetCloudQuota)->GetFunction());
+  Nan::Set(target,
+           Nan::New("getFileCount").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(GetFileCount)->GetFunction());
+  Nan::Set(target,
+           Nan::New("getFileNameAndSize").ToLocalChecked(),
+           Nan::New<v8::FunctionTemplate>(GetFileNameAndSize)->GetFunction());
 }
 
 SteamAPIRegistry::Add X(RegisterAPIs);

--- a/src/api/steam_api_cloud.cc
+++ b/src/api/steam_api_cloud.cc
@@ -158,12 +158,13 @@ NAN_METHOD(GetFileCount) {
 }
 
 NAN_METHOD(GetFileNameAndSize) {
+  Nan::HandleScope scope;
   v8::Local<v8::Object> result = Nan::New<v8::Object>();
   if (info.Length() < 1 || !info[0]->IsInt32()) {
     THROW_BAD_ARGS("Bad arguments");
   }
   int32 index = info[0].As<v8::Number>()->Int32Value();
-  int32 file_size;
+  int32 file_size = 0;
   const char* file_name =
       SteamRemoteStorage()->GetFileNameAndSize(index, &file_size);
   result->Set(Nan::New("name").ToLocalChecked(),


### PR DESCRIPTION
Closes #189 

API usage:
```
for (var i = 0; i < greenworks.getFileCount(); ++i)
  log(greenworks.getFileNameAndSize(i));
```