### PR TITLE
Write file when file name contains special characters.

### DIFF
--- a/src/greenworks_utils.cc
+++ b/src/greenworks_utils.cc
@@ -40,7 +40,7 @@ bool ReadFile(const char* path, char** content, int* length) {
 }
 
 bool WriteFile(const std::string& target_path, char* content, int length) {
-  std::ofstream fout(target_path.c_str(), std::ios::binary);
+  std::ofstream fout(target_path.c_str(), std::ios::out|std::ios::binary);
   fout.write(content, length);
   return fout.good();
 }


### PR DESCRIPTION
Fix #178. 

A win32 prebuilt binary for nw.js 0.35.3 can be downloaded from [here](https://drive.google.com/file/d/1RvvNEYXPEabt1iD6MnOVKa6_voZggTcI/view?usp=sharing)
CC @jhovgaard, @Eyesiah

