### PR TITLE
Update for Electron 5.0.0 Goodbye v8::Handle, Hello v8::Local

### DIFF
--- a/src/api/greenworks_api_utils.cc
+++ b/src/api/greenworks_api_utils.cc
@@ -60,7 +60,7 @@ NAN_METHOD(ExtractArchive) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> exports) {
+void RegisterAPIs(v8::Local<v8::Object> exports) {
   // Prepare constructor template
   v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>();
   Nan::SetMethod(tpl, "createArchive", CreateArchive);

--- a/src/api/steam_api_achievement.cc
+++ b/src/api/steam_api_achievement.cc
@@ -85,7 +85,7 @@ NAN_METHOD(GetNumberOfAchievements) {
   info.GetReturnValue().Set(steam_user_stats->GetNumAchievements());
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> target) {
+void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target,
            Nan::New("activateAchievement").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(ActivateAchievement)->GetFunction());

--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -148,7 +148,7 @@ NAN_METHOD(getTicketAppId) {
   info.GetReturnValue().Set(app_id);
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> target) {
+void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target,
            Nan::New("EncryptedAppTicketSymmetricKeyLength").ToLocalChecked(),
            Nan::New(k_nSteamEncryptedAppTicketSymmetricKeyLen));

--- a/src/api/steam_api_cloud.cc
+++ b/src/api/steam_api_cloud.cc
@@ -174,7 +174,7 @@ NAN_METHOD(GetFileNameAndSize) {
   info.GetReturnValue().Set(result);
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> target) {
+void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target,
            Nan::New("saveTextToFile").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(SaveTextToFile)->GetFunction());

--- a/src/api/steam_api_dlc.cc
+++ b/src/api/steam_api_dlc.cc
@@ -47,7 +47,7 @@ NAN_METHOD(uninstallDLC) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> target) {
+void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target, Nan::New("getDLCCount").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetDLCCount)->GetFunction());
   Nan::Set(target, Nan::New("isDLCInstalled").ToLocalChecked(),

--- a/src/api/steam_api_friends.cc
+++ b/src/api/steam_api_friends.cc
@@ -16,7 +16,7 @@ namespace greenworks {
 namespace api {
 namespace {
 
-void InitFriendFlags(v8::Handle<v8::Object> exports) {
+void InitFriendFlags(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> friend_flags = Nan::New<v8::Object>();
   SET_TYPE(friend_flags, "None", k_EFriendFlagNone);
   SET_TYPE(friend_flags, "Blocked", k_EFriendFlagBlocked);
@@ -41,7 +41,7 @@ void InitFriendFlags(v8::Handle<v8::Object> exports) {
            friend_flags);
 }
 
-void InitFriendRelationship(v8::Handle<v8::Object> exports) {
+void InitFriendRelationship(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> relationship = Nan::New<v8::Object>();
   SET_TYPE(relationship, "None", k_EFriendRelationshipNone);
   SET_TYPE(relationship, "Blocked", k_EFriendRelationshipBlocked);
@@ -61,7 +61,7 @@ void InitFriendRelationship(v8::Handle<v8::Object> exports) {
            relationship);
 }
 
-void InitFriendPersonaChange(v8::Handle<v8::Object> exports) {
+void InitFriendPersonaChange(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> persona_change = Nan::New<v8::Object>();
   SET_TYPE(persona_change, "Name", k_EPersonaChangeName);
   SET_TYPE(persona_change, "Status", k_EPersonaChangeStatus);
@@ -85,7 +85,7 @@ void InitFriendPersonaChange(v8::Handle<v8::Object> exports) {
            persona_change);
 }
 
-void InitAccountType(v8::Handle<v8::Object> exports) {
+void InitAccountType(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> account_type = Nan::New<v8::Object>();
   SET_TYPE(account_type, "Invalid", k_EAccountTypeInvalid);
   SET_TYPE(account_type, "Individual", k_EAccountTypeIndividual);
@@ -105,7 +105,7 @@ void InitAccountType(v8::Handle<v8::Object> exports) {
            account_type);
 }
 
-void InitChatEntryType(v8::Handle<v8::Object> exports) {
+void InitChatEntryType(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> chat_entry_type = Nan::New<v8::Object>();
   SET_TYPE(chat_entry_type, "Invalid", k_EChatEntryTypeInvalid);
   SET_TYPE(chat_entry_type, "ChatMsg", k_EChatEntryTypeChatMsg);
@@ -266,7 +266,7 @@ NAN_METHOD(GetFriendMessage) {
   info.GetReturnValue().Set(result);
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> exports) {
+void RegisterAPIs(v8::Local<v8::Object> exports) {
   InitFriendFlags(exports);
   InitFriendRelationship(exports);
   InitFriendPersonaChange(exports);

--- a/src/api/steam_api_registry.h
+++ b/src/api/steam_api_registry.h
@@ -25,14 +25,14 @@ namespace api {
 
 class SteamAPIRegistry {
  public:
-  typedef std::function<void(v8::Handle<v8::Object>)> RegistryFactory;
+  typedef std::function<void(v8::Local<v8::Object>)> RegistryFactory;
 
   static SteamAPIRegistry* GetInstance() {
     static SteamAPIRegistry steam_api_registry;
     return &steam_api_registry;
   }
 
-  void RegisterAllAPIs(v8::Handle<v8::Object> exports) {
+  void RegisterAllAPIs(v8::Local<v8::Object> exports) {
     for (const auto& factory : registry_factories_) {
       factory(exports);
     }

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -265,7 +265,7 @@ NAN_METHOD(GetImageRGBA) {
           .ToLocalChecked());
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> exports) {
+void RegisterAPIs(v8::Local<v8::Object> exports) {
   Nan::Set(exports,
            Nan::New("_version").ToLocalChecked(),
            Nan::New(GREENWORKS_VERSION).ToLocalChecked());

--- a/src/api/steam_api_stats.cc
+++ b/src/api/steam_api_stats.cc
@@ -133,7 +133,7 @@ NAN_METHOD(ResetAllStats) {
   info.GetReturnValue().Set(SteamUserStats()->ResetAllStats(reset_achievement));
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> target) {
+void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target, Nan::New("getStatInt").ToLocalChecked(),
            Nan::New<v8::FunctionTemplate>(GetStatInt)->GetFunction());
   Nan::Set(target, Nan::New("getStatFloat").ToLocalChecked(),

--- a/src/api/steam_api_workshop.cc
+++ b/src/api/steam_api_workshop.cc
@@ -13,7 +13,7 @@ namespace greenworks {
 namespace api {
 namespace {
 
-void InitUgcMatchingTypes(v8::Handle<v8::Object> exports) {
+void InitUgcMatchingTypes(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> ugc_matching_type = Nan::New<v8::Object>();
   SET_TYPE(ugc_matching_type, "Items", k_EUGCMatchingUGCType_Items);
   SET_TYPE(ugc_matching_type, "ItemsMtx", k_EUGCMatchingUGCType_Items_Mtx);
@@ -38,7 +38,7 @@ void InitUgcMatchingTypes(v8::Handle<v8::Object> exports) {
            ugc_matching_type);
 }
 
-void InitUgcQueryTypes(v8::Handle<v8::Object> exports) {
+void InitUgcQueryTypes(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> ugc_query_type = Nan::New<v8::Object>();
   SET_TYPE(ugc_query_type, "RankedByVote", k_EUGCQuery_RankedByVote);
   SET_TYPE(ugc_query_type, "RankedByPublicationDate",
@@ -67,7 +67,7 @@ void InitUgcQueryTypes(v8::Handle<v8::Object> exports) {
            ugc_query_type);
 }
 
-void InitUserUgcList(v8::Handle<v8::Object> exports) {
+void InitUserUgcList(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> ugc_list = Nan::New<v8::Object>();
   SET_TYPE(ugc_list, "Published", k_EUserUGCList_Published);
   SET_TYPE(ugc_list, "VotedOn", k_EUserUGCList_VotedOn);
@@ -83,7 +83,7 @@ void InitUserUgcList(v8::Handle<v8::Object> exports) {
   Nan::Set(exports, Nan::New("UserUGCList").ToLocalChecked(), ugc_list);
 }
 
-void InitUserUgcListSortOrder(v8::Handle<v8::Object> exports) {
+void InitUserUgcListSortOrder(v8::Local<v8::Object> exports) {
   v8::Local<v8::Object> ugc_list_sort_order = Nan::New<v8::Object>();
   SET_TYPE(ugc_list_sort_order, "CreationOrderDesc",
            k_EUserUGCListSortOrder_CreationOrderDesc);
@@ -374,7 +374,7 @@ NAN_METHOD(UGCUnsubscribe) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
-void RegisterAPIs(v8::Handle<v8::Object> exports) {
+void RegisterAPIs(v8::Local<v8::Object> exports) {
   InitUgcMatchingTypes(exports);
   InitUgcQueryTypes(exports);
   InitUserUgcListSortOrder(exports);


### PR DESCRIPTION
Electron 5.0 includes a version of V8 that has finally removed v8::Handle for good, and native Node.js addons that still use it will need to be updated before they can be used with Electron 5.0.
Replace all occurrences of v8::Handle with v8::Local. The former was just an alias of the latter, so no other changes need to be made to address this specific issue.

Updated the files in greenworks/src/api with the change. Compiled on MacOS with Electron 3.1.6, 4.1.1 and 5.0.0-beta.6. Tested running with Electron 5.0.0-beta.6 and basic Steamworks authentication and features worked.

[Handle change reference](https://electronjs.org/blog/nodejs-native-addons-and-electron-5)