### PR TITLE
This line is no longer needed

### DIFF
--- a/greenworks.js
+++ b/greenworks.js
@@ -10,8 +10,6 @@ var greenworks;
 if (process.platform == 'darwin') {
   if (process.arch == 'x64')
     greenworks = require('./lib/greenworks-osx64');
-  else if (process.arch == 'ia32')
-    greenworks = require('./lib/greenworks-osx32');
 } else if (process.platform == 'win32') {
   if (process.arch == 'x64')
     greenworks = require('./lib/greenworks-win64');


### PR DESCRIPTION
You do not support osx32 anymore, as there aren't any pre-built libraries for it.
Some lint plugins will pick up this and throw an error.