### PR TITLE
Update achievement activated.

### DIFF
--- a/samples/electron/main.js
+++ b/samples/electron/main.js
@@ -49,7 +49,7 @@ function testSteamAPI() {
           function() { log('Getting cloud quota successfully.') },
           function(err) { log('Failed on getting cloud quota.') });
 
-      greenworks.activateAchievement('achievement',
+      greenworks.activateAchievement('ACH_WIN_ONE_GAME',
           function() { log('Activating achievement successfully'); },
           function(err) { log('Failed on activating achievement.'); });
 

--- a/samples/electron/main.js
+++ b/samples/electron/main.js
@@ -48,7 +48,7 @@ function testSteamAPI() {
       greenworks.getCloudQuota(
           function() { log('Getting cloud quota successfully.') },
           function(err) { log('Failed on getting cloud quota.') });
-
+      // The ACH_WIN_ONE_GAME achievement is available for the sample (id:480) game
       greenworks.activateAchievement('ACH_WIN_ONE_GAME',
           function() { log('Activating achievement successfully'); },
           function(err) { log('Failed on activating achievement.'); });


### PR DESCRIPTION
Update achievement activated to one that is available for the sample steam game SpaceWar (id 480): ACH_WIN_ONE_GAME. Now, the example greenworks.activate call will succeed if the sample steam id is being used.