### PR TITLE
NaN Node 12.6 update for future versions of Electron / Node

### DIFF
--- a/src/api/steam_api_achievement.cc
+++ b/src/api/steam_api_achievement.cc
@@ -73,7 +73,7 @@ NAN_METHOD(GetAchievementNames) {
   auto count = static_cast<int>(SteamUserStats()->GetNumAchievements());
   v8::Local<v8::Array> names = Nan::New<v8::Array>(count);
   for (int i = 0; i < count; ++i) {
-    names->Set(
+    Nan::Set(names,
         i, Nan::New(SteamUserStats()->GetAchievementName(i)).ToLocalChecked());
   }
   info.GetReturnValue().Set(names);

--- a/src/api/steam_api_cloud.cc
+++ b/src/api/steam_api_cloud.cc
@@ -68,9 +68,9 @@ NAN_METHOD(SaveFilesToCloud) {
   v8::Local<v8::Array> files = info[0].As<v8::Array>();
   std::vector<std::string> files_path;
   for (uint32_t i = 0; i < files->Length(); ++i) {
-    if (!files->Get(i)->IsString())
+    if (!Nan::Get(files,i).ToLocalChecked()->IsString())
       THROW_BAD_ARGS("Bad arguments");
-    v8::String::Utf8Value string_array(files->Get(i));
+    v8::String::Utf8Value string_array(Nan::Get(files,i).ToLocalChecked());
     // Ignore empty path.
     if (string_array.length() > 0)
       files_path.push_back(*string_array);
@@ -167,9 +167,9 @@ NAN_METHOD(GetFileNameAndSize) {
   int32 file_size = 0;
   const char* file_name =
       SteamRemoteStorage()->GetFileNameAndSize(index, &file_size);
-  result->Set(Nan::New("name").ToLocalChecked(),
+  Nan::Set(result,Nan::New("name").ToLocalChecked(),
               Nan::New(file_name).ToLocalChecked());
-  result->Set(Nan::New("size").ToLocalChecked(),
+  Nan::Set(result,Nan::New("size").ToLocalChecked(),
               Nan::New(file_size));
   info.GetReturnValue().Set(result);
 }

--- a/src/api/steam_api_friends.cc
+++ b/src/api/steam_api_friends.cc
@@ -149,7 +149,7 @@ NAN_METHOD(GetFriends) {
 
   for (int i = 0; i < friends_count; ++i) {
     CSteamID steam_id = SteamFriends()->GetFriendByIndex(i, friend_flag);
-    friends->Set(i, greenworks::SteamID::Create(steam_id));
+    Nan::Set(friends,i, greenworks::SteamID::Create(steam_id));
   }
   info.GetReturnValue().Set(friends);
 }
@@ -259,9 +259,9 @@ NAN_METHOD(GetFriendMessage) {
       maximam_size, &chat_type);
 
   v8::Local<v8::Object> result = Nan::New<v8::Object>();
-  result->Set(Nan::New("message").ToLocalChecked(),
+  Nan::Set(result,Nan::New("message").ToLocalChecked(),
               Nan::New(message.get(), message_size).ToLocalChecked());
-  result->Set(Nan::New("chatEntryType").ToLocalChecked(),
+  Nan::Set(result,Nan::New("chatEntryType").ToLocalChecked(),
               Nan::New(chat_type));
   info.GetReturnValue().Set(result);
 }

--- a/src/api/steam_api_registry.h
+++ b/src/api/steam_api_registry.h
@@ -17,7 +17,7 @@
     } while (0);
 
 #define SET_TYPE(obj, type_name, type) \
-    obj->Set(Nan::New(type_name).ToLocalChecked(), \
+    Nan::Set(obj, Nan::New(type_name).ToLocalChecked(), \
              Nan::New(type))
 
 #define SET_FUNCTION(function_name, function)                 \

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -50,9 +50,9 @@ v8::Local<v8::Object> GetSteamUserCountType(int type_id) {
   };
   std::string name = account_types[type];
   v8::Local<v8::Object> account_type = Nan::New<v8::Object>();
-  account_type->Set(Nan::New("name").ToLocalChecked(),
+  Nan::Set(account_type,Nan::New("name").ToLocalChecked(),
                     Nan::New(name).ToLocalChecked());
-  account_type->Set(Nan::New("value").ToLocalChecked(), Nan::New(type_id));
+  Nan::Set(account_type,Nan::New("value").ToLocalChecked(), Nan::New(type_id));
   return account_type;
 }
 
@@ -86,56 +86,56 @@ NAN_METHOD(GetSteamId) {
   Nan::HandleScope scope;
   CSteamID user_id = SteamUser()->GetSteamID();
   v8::Local<v8::Object> flags = Nan::New<v8::Object>();
-  flags->Set(Nan::New("anonymous").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("anonymous").ToLocalChecked(),
              Nan::New(user_id.BAnonAccount()));
-  flags->Set(Nan::New("anonymousGameServer").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("anonymousGameServer").ToLocalChecked(),
              Nan::New(user_id.BAnonGameServerAccount()));
-  flags->Set(Nan::New("anonymousGameServerLogin").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("anonymousGameServerLogin").ToLocalChecked(),
              Nan::New(user_id.BBlankAnonAccount()));
-  flags->Set(Nan::New("anonymousUser").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("anonymousUser").ToLocalChecked(),
              Nan::New(user_id.BAnonUserAccount()));
-  flags->Set(Nan::New("chat").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("chat").ToLocalChecked(),
              Nan::New(user_id.BChatAccount()));
-  flags->Set(Nan::New("clan").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("clan").ToLocalChecked(),
              Nan::New(user_id.BClanAccount()));
-  flags->Set(Nan::New("consoleUser").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("consoleUser").ToLocalChecked(),
              Nan::New(user_id.BConsoleUserAccount()));
-  flags->Set(Nan::New("contentServer").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("contentServer").ToLocalChecked(),
              Nan::New(user_id.BContentServerAccount()));
-  flags->Set(Nan::New("gameServer").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("gameServer").ToLocalChecked(),
              Nan::New(user_id.BGameServerAccount()));
-  flags->Set(Nan::New("individual").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("individual").ToLocalChecked(),
              Nan::New(user_id.BIndividualAccount()));
-  flags->Set(Nan::New("gameServerPersistent").ToLocalChecked(),
+  Nan::Set(flags,Nan::New("gameServerPersistent").ToLocalChecked(),
              Nan::New(user_id.BPersistentGameServerAccount()));
-  flags->Set(Nan::New("lobby").ToLocalChecked(), Nan::New(user_id.IsLobby()));
+  Nan::Set(flags,Nan::New("lobby").ToLocalChecked(), Nan::New(user_id.IsLobby()));
 
   v8::Local<v8::Object> result = greenworks::SteamID::Create(user_id);
   // For backwards compatiblilty.
-  result->Set(Nan::New("flags").ToLocalChecked(), flags);
-  result->Set(Nan::New("type").ToLocalChecked(),
+  Nan::Set(result,Nan::New("flags").ToLocalChecked(), flags);
+  Nan::Set(result,Nan::New("type").ToLocalChecked(),
               GetSteamUserCountType(user_id.GetEAccountType()));
-  result->Set(Nan::New("accountId").ToLocalChecked(),
+  Nan::Set(result,Nan::New("accountId").ToLocalChecked(),
               Nan::New<v8::Integer>(user_id.GetAccountID()));
-  result->Set(Nan::New("steamId").ToLocalChecked(),
+  Nan::Set(result,Nan::New("steamId").ToLocalChecked(),
       Nan::New(utils::uint64ToString(
           user_id.ConvertToUint64())).ToLocalChecked());
-  result->Set(Nan::New("staticAccountId").ToLocalChecked(),
+  Nan::Set(result,Nan::New("staticAccountId").ToLocalChecked(),
       Nan::New(utils::uint64ToString(
           user_id.GetStaticAccountKey())).ToLocalChecked());
-  result->Set(Nan::New("isValid").ToLocalChecked(),
+  Nan::Set(result,Nan::New("isValid").ToLocalChecked(),
               Nan::New<v8::Integer>(user_id.IsValid()));
-  result->Set(Nan::New("level").ToLocalChecked(),
+  Nan::Set(result,Nan::New("level").ToLocalChecked(),
               Nan::New<v8::Integer>(SteamUser()->GetPlayerSteamLevel()));
 
   if (!SteamFriends()->RequestUserInformation(user_id, true)) {
-    result->Set(Nan::New("screenName").ToLocalChecked(),
+    Nan::Set(result,Nan::New("screenName").ToLocalChecked(),
                 Nan::New(SteamFriends()->GetFriendPersonaName(user_id))
                     .ToLocalChecked());
   } else {
     std::ostringstream sout;
     sout << user_id.GetAccountID();
-    result->Set(Nan::New("screenName").ToLocalChecked(),
+    Nan::Set(result,Nan::New("screenName").ToLocalChecked(),
                 Nan::New(sout.str()).ToLocalChecked());
   }
   info.GetReturnValue().Set(result);
@@ -237,8 +237,8 @@ NAN_METHOD(GetImageSize) {
     THROW_BAD_ARGS("Fail to get image size");
   }
   v8::Local<v8::Object> result = Nan::New<v8::Object>();
-  result->Set(Nan::New("width").ToLocalChecked(), Nan::New(width));
-  result->Set(Nan::New("height").ToLocalChecked(), Nan::New(height));
+  Nan::Set(result,Nan::New("width").ToLocalChecked(), Nan::New(width));
+  Nan::Set(result,Nan::New("height").ToLocalChecked(), Nan::New(height));
   info.GetReturnValue().Set(result);
 }
 

--- a/src/api/steam_api_workshop.cc
+++ b/src/api/steam_api_workshop.cc
@@ -134,22 +134,22 @@ NAN_METHOD(PublishWorkshopFile) {
   }
   Nan::MaybeLocal<v8::Object> maybe_opt = Nan::To<v8::Object>(info[0]);
   auto options = maybe_opt.ToLocalChecked();
-  auto app_id = options->Get(Nan::New("app_id").ToLocalChecked());
-  auto tags = options->Get(Nan::New("tags").ToLocalChecked());
-  if (!app_id->IsInt32() || !tags->IsArray()) {
+  auto app_id = Nan::Get(options,Nan::New("app_id").ToLocalChecked());
+  auto tags = Nan::Get(options,Nan::New("tags").ToLocalChecked());
+  if (!app_id.ToLocalChecked()->IsInt32() || !tags.ToLocalChecked()->IsArray()) {
     THROW_BAD_ARGS(
         "The object parameter must have 'app_id' and 'tags' field.");
   }
   greenworks::WorkshopFileProperties properties;
 
-  v8::Local<v8::Array> tags_array = tags.As<v8::Array>();
+  v8::Local<v8::Array> tags_array = tags.ToLocalChecked().As<v8::Array>();
   if (tags_array->Length() > greenworks::WorkshopFileProperties::MAX_TAGS) {
     THROW_BAD_ARGS("The length of 'tags' must be less than 100.");
   }
   for (uint32_t i = 0; i < tags_array->Length(); ++i) {
-    if (!tags_array->Get(i)->IsString())
+    if (!Nan::Get(tags_array,i).ToLocalChecked()->IsString())
       THROW_BAD_ARGS("Bad arguments");
-    v8::String::Utf8Value tag(tags_array->Get(i));
+    v8::String::Utf8Value tag(Nan::Get(tags_array,(i)).ToLocalChecked());
     properties.tags_scratch.push_back(*tag);
     properties.tags[i] = properties.tags_scratch.back().c_str();
   }
@@ -167,7 +167,7 @@ NAN_METHOD(PublishWorkshopFile) {
   properties.description = (*(v8::String::Utf8Value(info[4])));
 
   Nan::AsyncQueueWorker(new greenworks::PublishWorkshopFileWorker(
-      success_callback, error_callback, app_id->Int32Value(), properties));
+      success_callback, error_callback, app_id.ToLocalChecked()->Int32Value(), properties));
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
@@ -181,20 +181,20 @@ NAN_METHOD(UpdatePublishedWorkshopFile) {
   }
   Nan::MaybeLocal<v8::Object> maybe_opt = Nan::To<v8::Object>(info[0]);
   auto options = maybe_opt.ToLocalChecked();
-  auto tags = options->Get(Nan::New("tags").ToLocalChecked());
-  if (!tags->IsArray()) {
+  auto tags = Nan::Get(options,(Nan::New("tags").ToLocalChecked()));
+  if (!tags.ToLocalChecked()->IsArray()) {
     THROW_BAD_ARGS("The object parameter must have 'tags' field.");
   }
   greenworks::WorkshopFileProperties properties;
 
-  v8::Local<v8::Array> tags_array = tags.As<v8::Array>();
+  v8::Local<v8::Array> tags_array = tags.ToLocalChecked().As<v8::Array>();
   if (tags_array->Length() > greenworks::WorkshopFileProperties::MAX_TAGS) {
     THROW_BAD_ARGS("The length of 'tags' must be less than 100.");
   }
   for (uint32_t i = 0; i < tags_array->Length(); ++i) {
-    if (!tags_array->Get(i)->IsString())
+    if (!Nan::Get(tags_array,i).ToLocalChecked()->IsString())
       THROW_BAD_ARGS("Bad arguments");
-    v8::String::Utf8Value tag(tags_array->Get(i));
+    v8::String::Utf8Value tag(Nan::Get(tags_array,(i)).ToLocalChecked());
     properties.tags_scratch.push_back(*tag);
     properties.tags[i] = properties.tags_scratch.back().c_str();
   }
@@ -225,9 +225,9 @@ NAN_METHOD(UGCGetItems) {
   }
   Nan::MaybeLocal<v8::Object> maybe_opt = Nan::To<v8::Object>(info[0]);
   auto options = maybe_opt.ToLocalChecked();
-  auto app_id = options->Get(Nan::New("app_id").ToLocalChecked());
-  auto page_num = options->Get(Nan::New("page_num").ToLocalChecked());
-  if (!app_id->IsInt32() || !page_num->IsInt32()) {
+  auto app_id = Nan::Get(options,(Nan::New("app_id").ToLocalChecked()));
+  auto page_num = Nan::Get(options,(Nan::New("page_num").ToLocalChecked()));
+  if (!app_id.ToLocalChecked()->IsInt32() || !page_num.ToLocalChecked()->IsInt32()) {
     THROW_BAD_ARGS(
         "The object parameter must have 'app_id' and 'page_num' fields.");
   }
@@ -245,7 +245,7 @@ NAN_METHOD(UGCGetItems) {
 
   Nan::AsyncQueueWorker(new greenworks::QueryAllUGCWorker(
       success_callback, error_callback, ugc_matching_type, ugc_query_type,
-      app_id->Int32Value(), page_num->Int32Value()));
+      app_id.ToLocalChecked()->Int32Value(), page_num.ToLocalChecked()->Int32Value()));
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
@@ -257,9 +257,9 @@ NAN_METHOD(UGCGetUserItems) {
   }
   Nan::MaybeLocal<v8::Object> maybe_opt = Nan::To<v8::Object>(info[0]);
   auto options = maybe_opt.ToLocalChecked();
-  auto app_id = options->Get(Nan::New("app_id").ToLocalChecked());
-  auto page_num = options->Get(Nan::New("page_num").ToLocalChecked());
-  if (!app_id->IsInt32() || !page_num->IsInt32()) {
+  auto app_id = Nan::Get(options,(Nan::New("app_id").ToLocalChecked()));
+  auto page_num = Nan::Get(options,(Nan::New("page_num").ToLocalChecked()));
+  if (!app_id.ToLocalChecked()->IsInt32() || !page_num.ToLocalChecked()->IsInt32()) {
     THROW_BAD_ARGS(
         "The object parameter must have 'app_id' and 'page_num' fields.");
   }
@@ -279,7 +279,7 @@ NAN_METHOD(UGCGetUserItems) {
 
   Nan::AsyncQueueWorker(new greenworks::QueryUserUGCWorker(
       success_callback, error_callback, ugc_matching_type, ugc_list,
-      ugc_list_order, app_id->Int32Value(), page_num->Int32Value()));
+      ugc_list_order, app_id.ToLocalChecked()->Int32Value(), page_num.ToLocalChecked()->Int32Value()));
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
@@ -314,9 +314,9 @@ NAN_METHOD(UGCSynchronizeItems) {
 
   Nan::MaybeLocal<v8::Object> maybe_opt = Nan::To<v8::Object>(info[0]);
   auto options = maybe_opt.ToLocalChecked();
-  auto app_id = options->Get(Nan::New("app_id").ToLocalChecked());
-  auto page_num = options->Get(Nan::New("page_num").ToLocalChecked());
-  if (!app_id->IsInt32() || !page_num->IsInt32()) {
+  auto app_id = Nan::Get(options,(Nan::New("app_id").ToLocalChecked()));
+  auto page_num = Nan::Get(options,(Nan::New("page_num").ToLocalChecked()));
+  if (!app_id.ToLocalChecked()->IsInt32() || !page_num.ToLocalChecked()->IsInt32()) {
     THROW_BAD_ARGS(
         "The object parameter must have 'app_id' and 'page_num' fields.");
   }
@@ -331,7 +331,7 @@ NAN_METHOD(UGCSynchronizeItems) {
 
   Nan::AsyncQueueWorker(new greenworks::SynchronizeItemsWorker(
       success_callback, error_callback, download_dir,
-      app_id->Int32Value(), page_num->Int32Value()));
+      app_id.ToLocalChecked()->Int32Value(), page_num.ToLocalChecked()->Int32Value()));
   info.GetReturnValue().Set(Nan::Undefined());
 }
 

--- a/src/greenworks_async_workers.cc
+++ b/src/greenworks_async_workers.cc
@@ -312,11 +312,11 @@ void GetAuthSessionTicketWorker::OnGetAuthSessionCompleted(
 void GetAuthSessionTicketWorker::HandleOKCallback() {
   Nan::HandleScope scope;
   v8::Local<v8::Object> ticket = Nan::New<v8::Object>();
-  ticket->Set(
+  Nan::Set(ticket,
       Nan::New("ticket").ToLocalChecked(),
       Nan::CopyBuffer(reinterpret_cast<char*>(ticket_buf_), ticket_buf_size_)
           .ToLocalChecked());
-  ticket->Set(Nan::New("handle").ToLocalChecked(), Nan::New(handle_));
+  Nan::Set(ticket,Nan::New("handle").ToLocalChecked(), Nan::New(handle_));
   v8::Local<v8::Value> argv[] = { ticket };
   callback->Call(1, argv);
 }

--- a/src/greenworks_workshop_workers.cc
+++ b/src/greenworks_workshop_workers.cc
@@ -17,63 +17,63 @@ namespace {
 v8::Local<v8::Object> ConvertToJsObject(const SteamUGCDetails_t& item) {
   v8::Local<v8::Object> result = Nan::New<v8::Object>();
 
-  result->Set(Nan::New("acceptedForUse").ToLocalChecked(),
+  Nan::Set(result,Nan::New("acceptedForUse").ToLocalChecked(),
               Nan::New(item.m_bAcceptedForUse));
-  result->Set(Nan::New("banned").ToLocalChecked(),
+  Nan::Set(result,Nan::New("banned").ToLocalChecked(),
               Nan::New(item.m_bBanned));
-  result->Set(Nan::New("tagsTruncated").ToLocalChecked(),
+  Nan::Set(result,Nan::New("tagsTruncated").ToLocalChecked(),
               Nan::New(item.m_bTagsTruncated));
-  result->Set(Nan::New("fileType").ToLocalChecked(),
+  Nan::Set(result,Nan::New("fileType").ToLocalChecked(),
               Nan::New(item.m_eFileType));
-  result->Set(Nan::New("result").ToLocalChecked(),
+  Nan::Set(result,Nan::New("result").ToLocalChecked(),
               Nan::New(item.m_eResult));
-  result->Set(Nan::New("visibility").ToLocalChecked(),
+  Nan::Set(result,Nan::New("visibility").ToLocalChecked(),
               Nan::New(item.m_eVisibility));
-  result->Set(Nan::New("score").ToLocalChecked(),
+  Nan::Set(result,Nan::New("score").ToLocalChecked(),
               Nan::New(item.m_flScore));
 
-  result->Set(Nan::New("file").ToLocalChecked(),
+  Nan::Set(result,Nan::New("file").ToLocalChecked(),
               Nan::New(utils::uint64ToString(item.m_hFile)).ToLocalChecked());
-  result->Set(Nan::New("fileName").ToLocalChecked(),
+  Nan::Set(result,Nan::New("fileName").ToLocalChecked(),
               Nan::New(item.m_pchFileName).ToLocalChecked());
-  result->Set(Nan::New("fileSize").ToLocalChecked(),
+  Nan::Set(result,Nan::New("fileSize").ToLocalChecked(),
               Nan::New(item.m_nFileSize));
 
-  result->Set(Nan::New("previewFile").ToLocalChecked(),
+  Nan::Set(result,Nan::New("previewFile").ToLocalChecked(),
               Nan::New(
                   utils::uint64ToString(item.m_hPreviewFile)).ToLocalChecked());
-  result->Set(Nan::New("previewFileSize").ToLocalChecked(),
+  Nan::Set(result,Nan::New("previewFileSize").ToLocalChecked(),
               Nan::New(item.m_nPreviewFileSize));
 
-  result->Set(Nan::New("steamIDOwner").ToLocalChecked(),
+  Nan::Set(result,Nan::New("steamIDOwner").ToLocalChecked(),
               Nan::New(utils::uint64ToString(
                   item.m_ulSteamIDOwner)).ToLocalChecked());
-  result->Set(Nan::New("consumerAppID").ToLocalChecked(),
+  Nan::Set(result,Nan::New("consumerAppID").ToLocalChecked(),
               Nan::New(item.m_nConsumerAppID));
-  result->Set(Nan::New("creatorAppID").ToLocalChecked(),
+  Nan::Set(result,Nan::New("creatorAppID").ToLocalChecked(),
               Nan::New(item.m_nCreatorAppID));
-  result->Set(Nan::New("publishedFileId").ToLocalChecked(),
+  Nan::Set(result,Nan::New("publishedFileId").ToLocalChecked(),
               Nan::New(utils::uint64ToString(
                   item.m_nPublishedFileId)).ToLocalChecked());
 
-  result->Set(Nan::New("title").ToLocalChecked(),
+  Nan::Set(result,Nan::New("title").ToLocalChecked(),
               Nan::New(item.m_rgchTitle).ToLocalChecked());
-  result->Set(Nan::New("description").ToLocalChecked(),
+  Nan::Set(result,Nan::New("description").ToLocalChecked(),
               Nan::New(item.m_rgchDescription).ToLocalChecked());
-  result->Set(Nan::New("URL").ToLocalChecked(),
+  Nan::Set(result,Nan::New("URL").ToLocalChecked(),
               Nan::New(item.m_rgchURL).ToLocalChecked());
-  result->Set(Nan::New("tags").ToLocalChecked(),
+  Nan::Set(result,Nan::New("tags").ToLocalChecked(),
               Nan::New(item.m_rgchTags).ToLocalChecked());
 
-  result->Set(Nan::New("timeAddedToUserList").ToLocalChecked(),
+  Nan::Set(result,Nan::New("timeAddedToUserList").ToLocalChecked(),
               Nan::New(item.m_rtimeAddedToUserList));
-  result->Set(Nan::New("timeCreated").ToLocalChecked(),
+  Nan::Set(result,Nan::New("timeCreated").ToLocalChecked(),
               Nan::New(item.m_rtimeCreated));
-  result->Set(Nan::New("timeUpdated").ToLocalChecked(),
+  Nan::Set(result,Nan::New("timeUpdated").ToLocalChecked(),
               Nan::New(item.m_rtimeUpdated));
-  result->Set(Nan::New("votesDown").ToLocalChecked(),
+  Nan::Set(result,Nan::New("votesDown").ToLocalChecked(),
               Nan::New(item.m_unVotesDown));
-  result->Set(Nan::New("votesUp").ToLocalChecked(),
+  Nan::Set(result,Nan::New("votesUp").ToLocalChecked(),
               Nan::New(item.m_unVotesUp));
 
   return result;
@@ -257,7 +257,7 @@ void QueryUGCWorker::HandleOKCallback() {
   v8::Local<v8::Array> items = Nan::New<v8::Array>(
       static_cast<int>(ugc_items_.size()));
   for (size_t i = 0; i < ugc_items_.size(); ++i)
-    items->Set(i, ConvertToJsObject(ugc_items_[i]));
+    Nan::Set(items,i, ConvertToJsObject(ugc_items_[i]));
   v8::Local<v8::Value> argv[] = { items };
   callback->Call(1, argv);
 }
@@ -490,8 +490,8 @@ void SynchronizeItemsWorker::HandleOKCallback() {
     bool is_updated = std::find(download_ugc_items_handle_.begin(),
         download_ugc_items_handle_.end(), ugc_items_[i].m_hFile) !=
         download_ugc_items_handle_.end();
-    item->Set(Nan::New("isUpdated").ToLocalChecked(), Nan::New(is_updated));
-    items->Set(i, item);
+    Nan::Set(item,Nan::New("isUpdated").ToLocalChecked(), Nan::New(is_updated));
+    Nan::Set(items,i, item);
   }
   v8::Local<v8::Value> argv[] = { items };
   callback->Call(1, argv);


### PR DESCRIPTION
NaN Node 12.6 update, works (electron-quick-start) and compiles from Electron 3.0.9 up to Electron 7.0.0-beta.3. Previously Electron 7.0.0-beta.3 did not compile.

Example:
    items->Set(i, ConvertToJsObject(ugc_items_[i]));
to
    Nan::Set(items,i, ConvertToJsObject(ugc_items_[i]));