### PR TITLE
Added GetAppInstallDir method and documentation

### DIFF
--- a/docs/setting.md
+++ b/docs/setting.md
@@ -52,19 +52,8 @@ Not implement yet.
 ### greenworks.getAppInstallDir(app_id, buffer, buffer_size)
 
 * `app_id` Integer: The APP ID of your game
-* `buffer` Buffer: The buffer to write the path to
-* `buffer_size` Integer: The size of the buffer
 
-Fills the provided buffer with the absolute path to the app's installation directory.
-
-An example logging the installation path of an app matching id `1234`:
-```js
-var greenworks = require('./greenworks');
-const appId = 1234;
-const buffer = Buffer.alloc(260); // Maximum path length on win32 is 260 characters
-greenworks.getAppInstallDir(appId, buffer, buffer.length);
-console.log(`Installation directory: ${buffer.toString()}`);
-```
+Returns a `String` representing the absolute path to the app's installation directory.
 
 ### greenworks.getNumberOfPlayers(success_callback, [error_callback])
 

--- a/docs/setting.md
+++ b/docs/setting.md
@@ -49,6 +49,23 @@ Returns a `String` represents the current language from Steam set in UI.
 
 Not implement yet.
 
+### greenworks.getAppInstallDir(app_id, buffer, buffer_size)
+
+* `app_id` Integer: The APP ID of your game
+* `buffer` Buffer: The buffer to write the path to
+* `buffer_size` Integer: The size of the buffer
+
+Fills the provided buffer with the absolute path to the app's installation directory.
+
+An example logging the installation path of an app matching id `1234`:
+```js
+var greenworks = require('./greenworks');
+const appId = 1234;
+const buffer = Buffer.alloc(260); // Maximum path length on win32 is 260 characters
+greenworks.getAppInstallDir(appId, buffer, buffer.length);
+console.log(`Installation directory: ${buffer.toString()}`);
+```
+
 ### greenworks.getNumberOfPlayers(success_callback, [error_callback])
 
 * `success_callback` Function(num_of_players)

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -168,13 +168,17 @@ NAN_METHOD(GetCurrentGameInstallDir) {
 
 NAN_METHOD(GetAppInstallDir) {
   Nan::HandleScope scope;
-  if (info.Length() < 3 || !info[0]->IsUint32() || !info[2]->IsUint32()) {
-    THROW_BAD_ARGS("Bad arguments; expected: appid [uint32], destination [char buffer], destination size [uint32]");
+  
+  if (info.Length() < 1 || !info[0]->IsUint32()) {
+    THROW_BAD_ARGS("Bad arguments; expected: appid [uint32]");
   }
+
   AppId_t app_id = static_cast<AppId_t>(info[0]->Uint32Value());
-  char* buffer = (char*) node::Buffer::Data(info[1]->ToObject());
-  uint32 buffer_size = info[2]->Uint32Value();
+  const int buffer_size = 260;  // MAX_PATH on 32bit Windows according to MSDN documentation
+  char buffer[buffer_size];
   SteamApps()->GetAppInstallDir(app_id, buffer, buffer_size);
+
+  info.GetReturnValue().Set(Nan::New(buffer, buffer_size).ToLocalChecked());
 }
 
 NAN_METHOD(GetNumberOfPlayers) {

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -176,9 +176,9 @@ NAN_METHOD(GetAppInstallDir) {
   AppId_t app_id = static_cast<AppId_t>(info[0]->Uint32Value());
   const int buffer_size = 260;  // MAX_PATH on 32bit Windows according to MSDN documentation
   char buffer[buffer_size];
-  SteamApps()->GetAppInstallDir(app_id, buffer, buffer_size);
+  uint32 length = SteamApps()->GetAppInstallDir(app_id, buffer, buffer_size);
 
-  info.GetReturnValue().Set(Nan::New(buffer, buffer_size).ToLocalChecked());
+  info.GetReturnValue().Set(Nan::New(buffer, length - 1).ToLocalChecked());
 }
 
 NAN_METHOD(GetNumberOfPlayers) {

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -178,6 +178,7 @@ NAN_METHOD(GetAppInstallDir) {
   char buffer[buffer_size];
   uint32 length = SteamApps()->GetAppInstallDir(app_id, buffer, buffer_size);
 
+  // The length takes \0 termination into account; return length-1 to remove it since Javascript has trouble handling it
   info.GetReturnValue().Set(Nan::New(buffer, length - 1).ToLocalChecked());
 }
 

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -166,6 +166,17 @@ NAN_METHOD(GetCurrentGameInstallDir) {
   info.GetReturnValue().Set(Nan::New("NOT IMPLEMENTED").ToLocalChecked());
 }
 
+NAN_METHOD(GetAppInstallDir) {
+  Nan::HandleScope scope;
+  if (info.Length() < 3 || !info[0]->IsUint32() || !info[2]->IsUint32()) {
+    THROW_BAD_ARGS("Bad arguments; expected: appid [uint32], destination [char buffer], destination size [uint32]");
+  }
+  AppId_t app_id = static_cast<AppId_t>(info[0]->Uint32Value());
+  char* buffer = (char*) node::Buffer::Data(info[1]->ToObject());
+  uint32 buffer_size = info[2]->Uint32Value();
+  SteamApps()->GetAppInstallDir(app_id, buffer, buffer_size);
+}
+
 NAN_METHOD(GetNumberOfPlayers) {
   Nan::HandleScope scope;
   if (info.Length() < 1 || !info[0]->IsFunction()) {
@@ -278,6 +289,7 @@ void RegisterAPIs(v8::Local<v8::Object> target) {
   SET_FUNCTION("getCurrentGameLanguage", GetCurrentGameLanguage);
   SET_FUNCTION("getCurrentUILanguage", GetCurrentUILanguage);
   SET_FUNCTION("getCurrentGameInstallDir", GetCurrentGameInstallDir);
+  SET_FUNCTION("getAppInstallDir", GetAppInstallDir);
   SET_FUNCTION("getNumberOfPlayers", GetNumberOfPlayers);
   SET_FUNCTION("isGameOverlayEnabled", IsGameOverlayEnabled);
   SET_FUNCTION("activateGameOverlay", ActivateGameOverlay);


### PR DESCRIPTION
Since GetCurrentGameInstallDir is not implemented and I couldn't be sure of its intention I implemented GetAppInstallDir to match Steam's API: https://partner.steamgames.com/doc/api/ISteamApps#GetAppInstallDir

I tested it in my project using win64 and it worked as expected, I did not test other architectures. I added an entry to the documentation, let me know if I should add anything else or if you'd like me to adjust it in any way.