### PR TITLE
Added API to detect Steam's big picture mode

### DIFF
--- a/docs/setting.md
+++ b/docs/setting.md
@@ -76,6 +76,11 @@ Activate the game overlay with the `option` dialog opens.
 
 Return `Boolean` indicates whether Steam overlay is enabled/disabled.
 
+### greenworks.isSteamInBigPictureMode()
+
+Return `Boolean` indicates whether Steam is in Big Picture mode. 
+Will always return `false` if the application is not in Steam's `game` category.
+
 ### greenworks.activateGameOverlayToWebPage(url)
 
 * `url` String: a full url, e.g. http://www.steamgames.com.

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -211,6 +211,11 @@ NAN_METHOD(IsGameOverlayEnabled) {
   info.GetReturnValue().Set(Nan::New(SteamUtils()->IsOverlayEnabled()));
 }
 
+NAN_METHOD(IsSteamInBigPictureMode) {
+  Nan::HandleScope scope;
+  info.GetReturnValue().Set(Nan::New(SteamUtils()->IsSteamInBigPictureMode()));
+}
+
 NAN_METHOD(ActivateGameOverlay) {
   Nan::HandleScope scope;
   if (info.Length() < 1 || !info[0]->IsString()) {
@@ -315,6 +320,7 @@ void RegisterAPIs(v8::Local<v8::Object> target) {
   SET_FUNCTION("getAppInstallDir", GetAppInstallDir);
   SET_FUNCTION("getNumberOfPlayers", GetNumberOfPlayers);
   SET_FUNCTION("isGameOverlayEnabled", IsGameOverlayEnabled);
+  SET_FUNCTION("isSteamInBigPictureMode", IsSteamInBigPictureMode);
   SET_FUNCTION("activateGameOverlay", ActivateGameOverlay);
   SET_FUNCTION("activateGameOverlayToWebPage", ActivateGameOverlayToWebPage);
   SET_FUNCTION("isAppInstalled", IsAppInstalled);


### PR DESCRIPTION
To allow applications to behave differently when Steam is in big picture mode, I exposed the `SteamUtils` API call allowing to detect it. It can be tested easily by adding a greenworks application to Steam as an external game and starting it through big picture.