### PR TITLE
Implement missing ISteamUtils::GetIPCountry function

### DIFF
--- a/docs/setting.md
+++ b/docs/setting.md
@@ -147,3 +147,7 @@ if (friends.length > 0) {
   image.write("/tmp/test.png");
 }
 ```
+
+### greenworks.getIPCountry()
+
+Returns the 2 digit ISO 3166-1-alpha-2 format country code which client is running in, e.g "US" or "UK".

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -304,6 +304,12 @@ NAN_METHOD(GetImageRGBA) {
           .ToLocalChecked());
 }
 
+NAN_METHOD(GetIPCountry) {
+  Nan::HandleScope scope;
+  const char* countryCode = SteamUtils()->GetIPCountry();
+  info.GetReturnValue().Set(Nan::New(countryCode, 2).ToLocalChecked());
+}
+
 void RegisterAPIs(v8::Local<v8::Object> target) {
   Nan::Set(target,
            Nan::New("_version").ToLocalChecked(),
@@ -327,6 +333,7 @@ void RegisterAPIs(v8::Local<v8::Object> target) {
   SET_FUNCTION("isSubscribedApp", IsSubscribedApp);
   SET_FUNCTION("getImageSize", GetImageSize);
   SET_FUNCTION("getImageRGBA", GetImageRGBA);
+  SET_FUNCTION("getIPCountry", GetIPCountry);
 }
 
 SteamAPIRegistry::Add X(RegisterAPIs);


### PR DESCRIPTION
Found myself in need of knowing the user's location as reported by Steam so I exposed Steam's method to get the country code based on user IP.