### PR TITLE
Fix incorrect index in CancelAuthTicket

### DIFF
--- a/src/api/steam_api_auth.cc
+++ b/src/api/steam_api_auth.cc
@@ -35,7 +35,7 @@ NAN_METHOD(CancelAuthTicket) {
   if (info.Length() < 1 || !info[0]->IsNumber()) {
     THROW_BAD_ARGS("Bad arguments");
   }
-  HAuthTicket h = Nan::To<int32>(info[1].As<v8::Number>()).FromJust();
+  HAuthTicket h = Nan::To<int32>(info[0].As<v8::Number>()).FromJust();
   SteamUser()->CancelAuthTicket(h);
   info.GetReturnValue().Set(Nan::Undefined());
 }


### PR DESCRIPTION
From my observation, it appears that the wrong index is being used in `CancelAuthTicket`. The function is only expecting one argument, and checks the argument in index 0 only to then to cast the argument at index 1. This seems like it would prevent authentication tickets from ever being invalidated by this call.