### PR TITLE
Implement ActivateGameOverlayToStore from ISteamFriends

### DIFF
--- a/docs/friends.md
+++ b/docs/friends.md
@@ -369,3 +369,15 @@ Valid pchDialog options are:
 * "friendremove" - Opens the overlay in minimal mode prompting the user to remove the target friend.
 * "friendrequestaccept" - Opens the overlay in minimal mode prompting the user to accept an incoming friend invite.
 * "friendrequestignore" - Opens the overlay in minimal mode prompting the user to ignore an incoming friend invite.
+
+### greenworks.activateGameOverlayToStore(appId, EOverlayToStoreFlag storeFlag)
+
+Activates the Steam Overlay to the Steam store page for the provided app.
+
+* `appId` Integer: The app ID to show the store page of.
+* `storeFlag` Integer: Flags to modify the behavior when the page opens.
+
+Valid storeFlag options are:
+* 0 - No
+* 1 - Add the specified app ID to the users cart.
+* 2 - Add the specified app ID to the users cart and show the store page.

--- a/src/api/steam_api_settings.cc
+++ b/src/api/steam_api_settings.cc
@@ -236,6 +236,19 @@ NAN_METHOD(ActivateGameOverlayToWebPage) {
   info.GetReturnValue().Set(Nan::Undefined());
 }
 
+NAN_METHOD(ActivateGameOverlayToStore) {
+  Nan::HandleScope scope;
+  if (info.Length() < 2 || !info[0]->IsUint32() || !info[1]->IsUint32()) {
+    THROW_BAD_ARGS("bad arguments");
+  }
+
+  AppId_t app_id = static_cast<AppId_t>(Nan::To<int32>(info[0]).FromJust());
+  auto overlay_store_flag = static_cast<EOverlayToStoreFlag>(Nan::To<int32>(info[1]).FromJust());
+
+  SteamFriends()->ActivateGameOverlayToStore(app_id, overlay_store_flag);
+  info.GetReturnValue().Set(Nan::Undefined());
+}
+
 NAN_METHOD(IsSubscribedApp) {
   Nan::HandleScope scope;
   if (info.Length() < 1) {
@@ -344,6 +357,7 @@ void RegisterAPIs(v8::Local<v8::Object> target) {
   SET_FUNCTION("isSteamInBigPictureMode", IsSteamInBigPictureMode);
   SET_FUNCTION("activateGameOverlay", ActivateGameOverlay);
   SET_FUNCTION("activateGameOverlayToWebPage", ActivateGameOverlayToWebPage);
+  SET_FUNCTION("activateGameOverlayToStore", ActivateGameOverlayToStore);
   SET_FUNCTION("isAppInstalled", IsAppInstalled);
   SET_FUNCTION("isSubscribedApp", IsSubscribedApp);
   SET_FUNCTION("getImageSize", GetImageSize);


### PR DESCRIPTION
## Description
Implements the [ActivateGameOverlayToStore](https://partner.steamgames.com/doc/api/ISteamFriends#ActivateGameOverlayToStore) function.

This is useful for store interaction through the steam overlay, as described in [DLC > In-Game Purchasing](https://partner.steamgames.com/doc/store/application/dlc).

## Screenshot
![image](https://user-images.githubusercontent.com/4903529/98189894-4085e800-1f59-11eb-8c51-ecd242796336.png)

Here is a example flow
1. In-game the player pick the contents he wants
2. Without leaving the game, the user is directly logged-in with his steam account, and he is shown his cart in the steam Overlay with the right DLC he choose in-game
3. When the user installed the DLC, we get this event (the installation is managed through steam and can happen at any point, even weeks later)
```js
greenworks.on('dlc-installed', (args) => console.log(`Greenworks - Detect DLC installation`, args))
```
4. At that time, just to be sure it's better to check with steam that the user [own the DLC](https://partner.steamgames.com/doc/api/ISteamApps#BIsDlcInstalled)
```js
greenworks.isDLCInstalled(dlcAppId)
```
5. We are good to go, the user got some extra contents, we know it and we can let him access it

## Extra
It's highly recommended to test `greenworks.isGameOverlayEnabled()` before, and if it's false, find another way to redirect the user to the store which does not rely on the overlay.

## Status of Overlay API

Existing API:
* [greenworks.isGameOverlayEnabled()](https://github.com/greenheartgames/greenworks/blob/master/docs/setting.md)
* [greenworks.activateGameOverlayInviteDialog(steamIDLobby)](https://github.com/greenheartgames/greenworks/blob/master/docs/friends.md)
* [greenworks.activateGameOverlayToUser(pchDialog, CSteamID steamID)](https://github.com/greenheartgames/greenworks/blob/master/docs/friends.md)
* [greenworks.activateGameOverlay(option)](https://github.com/greenheartgames/greenworks/blob/master/docs/setting.md)
* [greenworks.activateGameOverlayToWebPage(url)](https://github.com/greenheartgames/greenworks/blob/master/docs/setting.md)

Missing Steam API:
* [ActivateGameOverlayToStore](https://partner.steamgames.com/doc/api/ISteamFriends#ActivateGameOverlayToStore) : This PR
* ~~[ActivateGameOverlayToWebPage](https://partner.steamgames.com/doc/api/ISteamFriends#ActivateGameOverlayToWebPage): Activates Steam Overlay web browser directly to the specified URL.~~
* ~~[ActivateGameOverlay](https://partner.steamgames.com/doc/api/ISteamFriends#ActivateGameOverlay): not really needed, only an alias of ActivateGameOverlayToUser~~