### PR TITLE
fixed: uint64 to string conversion didn't work

### DIFF
--- a/src/greenworks_utils.cc
+++ b/src/greenworks_utils.cc
@@ -67,9 +67,7 @@ int64 GetFileLastUpdatedTime(const char* file_path) {
 }
 
 std::string uint64ToString(uint64 value) {
-  std::ostringstream sout;
-  sout << value;
-  return sout.str();
+  return std::to_string(value);
 }
 
 uint64 strToUint64(std::string str) {


### PR DESCRIPTION
uin64 to string conversion didn't work.
e.g: The publishedFileId is wrong when getting workshopItems with UGCGetItems.