### PR TITLE
Added extra Steamworks version info to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,8 @@ Since then, it has been open-sourced and is
   * node v0.8, v0.10, v0.12, v4, v5, v6, v7, v8, v9 and v10
   * NW.js v0.8, v0.11+
   * Electron v1.0.0+
-  * Steam SDK v1.42 
+  * Steam SDK v1.42 support in [official releases](https://github.com/greenheartgames/greenworks/releases).
+  * Steam SDK v1.50+ support in [daily automated builds](https://greenworks-prebuilds.armaldio.xyz/) provided by [@armaldio](https://github.com/armaldio). See the [greenworks-prebuilds](https://github.com/ElectronForConstruct/greenworks-prebuilds) repository for the latest supported Steam SDK version.
 * Greenworks is built using [Native Abstractions for Node.js](https://github.com/nodejs/nan) to
 support different node versions.
 * The project is currently funded by Greenheart Games and other


### PR DESCRIPTION
Lately, I was fixing this weird bug that greenworks-win64.node module couldn't be found, but the file was there. As this is a common issue, it was clear that some Steam files couldn't be found or that the architecture wasn't right.

I was using a daily automated build in combination with Steam SDK v1.42. I fixed my issue by using Steam SDK v1.50, after looking at [this repository](https://github.com/ElectronForConstruct/greenworks-prebuilds).

I couldn't find anything about newer supported Steam SDK versions here, so I've updated the README.