### PR TITLE
Update compilation flags from c++11 to c++14

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -132,7 +132,7 @@
           }],
         ],
       },
-      'cflags': [ '-std=c++11' ],
+      'cflags': [ '-std=c++14' ],
       'conditions': [
         ['OS== "linux"',
           {
@@ -168,7 +168,7 @@
           '-Wno-deprecated-declarations',
         ],
         'OTHER_CPLUSPLUSFLAGS' : [
-          '-std=c++11',
+          '-std=c++14',
           '-stdlib=libc++'
         ],
         'OTHER_LDFLAGS': [


### PR DESCRIPTION
Confirmed to fix #289 

Build for all platform (Win, Mac, Linux)(x64, x86)

Proof: https://github.com/ElectronForConstruct/greenworks-prebuilds/actions/runs/705461631
Don't mind the red cross, it just means that the files failed to upload
You can go to every step matrix and check the "Build" entry log