### PR TITLE
Build universal binary for mac.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,21 +32,10 @@
       ],
     }],
     ['OS=="mac"', {
-      'conditions': [
-        ['target_arch=="ia32"', {
-          'variables': {
-            'project_name': 'greenworks-osx32',
-          },
-        }],
-        ['target_arch=="x64"', {
-          'variables': {
-            'project_name': 'greenworks-osx64',
-          },
-        }],
-      ],
       'variables': {
-        'redist_bin_dir': 'osx32',
-        'public_lib_dir': 'osx32',
+        'project_name': 'greenworks-osx',
+        'redist_bin_dir': 'osx',
+        'public_lib_dir': 'osx',
         'lib_steam': 'libsteam_api.dylib',
         'lib_encryptedappticket': 'libsdkencryptedappticket.dylib',
       },
@@ -169,9 +158,14 @@
         ],
         'OTHER_CPLUSPLUSFLAGS' : [
           '-std=c++14',
+          '-arch x86_64',
+          '-arch arm64',
           '-stdlib=libc++'
         ],
+
         'OTHER_LDFLAGS': [
+          '-arch x86_64',
+          '-arch arm64',
           '-stdlib=libc++'
         ],
       },

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -117,8 +117,8 @@
           'xcode_settings': {
             # Build universal binary to support M1 (Apple silicon)
             'OTHER_CFLAGS': [
-              "-arch x86_64",
-              "-arch arm64"
+              '-arch x86_64',
+              '-arch arm64'
             ],
           }
         }],

--- a/deps/zlib/zlib.gyp
+++ b/deps/zlib/zlib.gyp
@@ -57,6 +57,17 @@
             ],
           },
         ],
+        ['OS=="mac"',
+          {
+            'xcode_settings': {
+              # Build universal binary to support M1 (Apple silicon)
+              'OTHER_CFLAGS': [
+                '-arch x86_64',
+                '-arch arm64'
+              ]
+            }
+          },
+        ]
       ],
       'msvs_disabled_warnings': [
         4244,  # conversion from '__int64' to 'long'(gzlib.c)
@@ -103,6 +114,13 @@
           'defines': [
             'USE_FILE32API'
           ],
+          'xcode_settings': {
+            # Build universal binary to support M1 (Apple silicon)
+            'OTHER_CFLAGS': [
+              "-arch x86_64",
+              "-arch arm64"
+            ],
+          }
         }],
         ['clang==1', {
           'xcode_settings': {

--- a/greenworks.js
+++ b/greenworks.js
@@ -8,8 +8,7 @@ var fs = require('fs');
 var greenworks;
 
 if (process.platform == 'darwin') {
-  if (process.arch == 'x64')
-    greenworks = require(__dirname + '/lib/greenworks-osx64');
+  greenworks = require(__dirname + '/lib/greenworks-osx');
 } else if (process.platform == 'win32') {
   if (process.arch == 'x64')
     greenworks = require(__dirname + '/lib/greenworks-win64');


### PR DESCRIPTION
Similar to the libraries provided by the steamworks SDK, we build greenworks addon as a universal binary now, for both x86_64 and arm64.

The i386 arch is deprecated on mac now, remove it.