### PR TITLE
Update Electron example to allow the Steam overlay to work

### DIFF
--- a/samples/electron/start.js
+++ b/samples/electron/start.js
@@ -6,6 +6,8 @@ const BrowserWindow = electron.BrowserWindow;
 
 var mainWindow = null;
 
+app.commandLine.appendSwitch('--in-process-gpu', '--disable-direct-composition'); // Allows the Steam overlay to work
+
 app.on('window-all-closed', function() {
   if (process.platform != 'darwin')
     app.quit();


### PR DESCRIPTION
Reference: https://www.reddit.com/r/gamedev/comments/mc9s5x/has_anyone_successfully_integrate_steam_overlay/

In my tests (on only one system), only `--in-process-gpu` seemed to be required though (possibly `--disable-direct-composition` is only for older Chromium/Electron versions...)