### PR TITLE
Fix NAN usages in steam_api_matchmaking.cc

### DIFF
--- a/src/api/steam_api_matchmaking.cc
+++ b/src/api/steam_api_matchmaking.cc
@@ -566,11 +566,11 @@ NAN_METHOD(GetLobbyChatEntry) {
     return;
   }
 
-  v8::String::Utf8Value str(info[0]->ToString());
+  Nan::Utf8String str(info[0]);
   std::string lobbyIdStr(*str);
   CSteamID steamIDLobby(static_cast<uint64>(std::stoull(lobbyIdStr)));
 
-  int iChatID = info[1]->Int32Value();
+  int iChatID = info[1]->Int32Value(Nan::GetCurrentContext()).FromJust();
 
   CSteamID steamIDUser;
   char dataBuffer[4096];


### PR DESCRIPTION
Update GetLobbyChatEntry method to use NAN API functions:

1. Replace v8::String::Utf8Value with Nan::Utf8String for string handling
2. Update Int32Value() call to use the context-aware version